### PR TITLE
Licence typo, duplicated property and add ebean as module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: java
 
 jdk:
-    - openjdk7
+    - openjdk8
     
 before_script:
     - chmod +x ./share/deploy/deploy-snapshot.sh

--- a/billy-core-ebean/pom.xml
+++ b/billy-core-ebean/pom.xml
@@ -1,13 +1,13 @@
-<!-- ~ Copyright (C) 2013 Premium Minds. ~ ~ This file is part of billy-core-jpa.
-	~ ~ billy-core-jpa is free software: you can redistribute it and/or modify
+<!-- ~ Copyright (C) 2017 Premium Minds. ~ ~ This file is part of billy-core-ebean.
+	~ ~ billy-core-ebean is free software: you can redistribute it and/or modify
 	~ it under the terms of the GNU Lesser General Public License as published
 	~ by the Free Software Foundation, either version 3 of the License, or ~
-	(at your option) any later version. ~ ~ billy-core-jpa is distributed in
+	(at your option) any later version. ~ ~ billy-core-ebean is distributed in
 	the hope that it will be useful, ~ but WITHOUT ANY WARRANTY; without even
 	the implied warranty of ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 	See the ~ GNU Lesser General Public License for more details. ~ ~ You should
 	have received a copy of the GNU Lesser General Public License ~ along with
-	billy-core-jpa. If not, see <http://www.gnu.org/licenses />. -->
+	billy-core-ebean. If not, see <http://www.gnu.org/licenses />. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/billy-core-jpa/pom.xml
+++ b/billy-core-jpa/pom.xml
@@ -28,7 +28,6 @@
 		<guice.version>3.0</guice.version>
 		<env>DEV</env>
 
-		<querydsl.version>2.9.0</querydsl.version>
 		<hibernate.version>4.2.3.Final</hibernate.version>
 		<querydsl.version>3.2.2</querydsl.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 	<modules>
 		<module>billy-core</module>
 		<module>billy-core-jpa</module>
+		<module>billy-core-ebean</module>
 		<module>billy-gin</module>
 		<module>billy-portugal</module>
 		<module>billy-spain</module>


### PR DESCRIPTION
The only real change is the addition of billy-core-ebean as module