### PR TITLE
Remove log4j dependency and use only slf4j-api, to allow each program to

### DIFF
--- a/billy-core-ebean/pom.xml
+++ b/billy-core-ebean/pom.xml
@@ -88,17 +88,11 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/billy-core-jpa/pom.xml
+++ b/billy-core-jpa/pom.xml
@@ -94,16 +94,9 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<!-- Query DSL -->

--- a/billy-core/pom.xml
+++ b/billy-core/pom.xml
@@ -91,16 +91,9 @@
 			<artifactId>mockito-all</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<!-- SnakeYaml -->

--- a/billy-france/pom.xml
+++ b/billy-france/pom.xml
@@ -119,16 +119,9 @@
 			<artifactId>mockito-all</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-gin/pom.xml
+++ b/billy-gin/pom.xml
@@ -79,16 +79,9 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-portugal-ebean/pom.xml
+++ b/billy-portugal-ebean/pom.xml
@@ -100,16 +100,9 @@
 			<artifactId>mockito-all</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -120,16 +120,9 @@
 			<artifactId>mockito-all</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-spain/pom.xml
+++ b/billy-spain/pom.xml
@@ -119,16 +119,9 @@
 			<artifactId>mockito-all</artifactId>
 		</dependency>
 
-		<!-- LOG4J -->
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.4</version>
+			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
 
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.29</version>
+			</dependency>
+
 			<!-- GUICE -->
 			<dependency>
 				<groupId>com.google.inject</groupId>


### PR DESCRIPTION
choose its own logger implementation as is the intention of slf4j

http://www.slf4j.org/faq.html#maven2