### PR TITLE
Clarify isSubContext in DAOContext

### DIFF
--- a/billy-core-ebean/src/main/java/com/premiumminds/billy/core/persistence/dao/ebean/DAOContextImpl.java
+++ b/billy-core-ebean/src/main/java/com/premiumminds/billy/core/persistence/dao/ebean/DAOContextImpl.java
@@ -37,12 +37,12 @@ public class DAOContextImpl extends AbstractDAO<ContextEntity, JPAContextEntity>
 
     @Override
     public boolean isSameOrSubContext(Context sub, Context context) {
-		if (sub.getUID().equals(context.getUID())) {
-			return true;
-		}
-		if (sub.getParentContext() == null) {
-			return false;
-		}
+        if (sub.getUID().equals(context.getUID())) {
+            return true;
+        }
+        if (sub.getParentContext() == null) {
+            return false;
+        }
         if (sub.getParentContext().getUID().equals(context.getUID())) {
             return true;
         }

--- a/billy-core-ebean/src/main/java/com/premiumminds/billy/core/persistence/dao/ebean/DAOContextImpl.java
+++ b/billy-core-ebean/src/main/java/com/premiumminds/billy/core/persistence/dao/ebean/DAOContextImpl.java
@@ -36,17 +36,17 @@ public class DAOContextImpl extends AbstractDAO<ContextEntity, JPAContextEntity>
     }
 
     @Override
-    public boolean isSubContext(Context sub, Context context) {
-        if (sub.getParentContext() == null) {
-            return false;
-        }
-        if (sub.getUID().equals(context.getUID())) {
-            return true;
-        }
+    public boolean isSameOrSubContext(Context sub, Context context) {
+		if (sub.getUID().equals(context.getUID())) {
+			return true;
+		}
+		if (sub.getParentContext() == null) {
+			return false;
+		}
         if (sub.getParentContext().getUID().equals(context.getUID())) {
             return true;
         }
-        return this.isSubContext(sub.getParentContext(), context);
+        return this.isSameOrSubContext(sub.getParentContext(), context);
     }
 
 }

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/core/persistence/dao/jpa/DAOContextImpl.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/core/persistence/dao/jpa/DAOContextImpl.java
@@ -45,17 +45,17 @@ public class DAOContextImpl extends AbstractDAO<ContextEntity, JPAContextEntity>
     }
 
     @Override
-    public boolean isSubContext(Context sub, Context context) {
-        if (sub.getParentContext() == null) {
-            return false;
-        }
-        if (sub.getUID().equals(context.getUID())) {
+    public boolean isSameOrSubContext(Context sub, Context context) {
+		if (sub.getUID().equals(context.getUID())) {
+			return true;
+		}
+		if (sub.getParentContext() == null) {
+			return false;
+		}
+		if (sub.getParentContext().getUID().equals(context.getUID())) {
             return true;
         }
-        if (sub.getParentContext().getUID().equals(context.getUID())) {
-            return true;
-        }
-        return this.isSubContext(sub.getParentContext(), context);
+        return this.isSameOrSubContext(sub.getParentContext(), context);
     }
 
 }

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/core/persistence/dao/jpa/DAOContextImpl.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/core/persistence/dao/jpa/DAOContextImpl.java
@@ -46,13 +46,13 @@ public class DAOContextImpl extends AbstractDAO<ContextEntity, JPAContextEntity>
 
     @Override
     public boolean isSameOrSubContext(Context sub, Context context) {
-		if (sub.getUID().equals(context.getUID())) {
-			return true;
-		}
-		if (sub.getParentContext() == null) {
-			return false;
-		}
-		if (sub.getParentContext().getUID().equals(context.getUID())) {
+        if (sub.getUID().equals(context.getUID())) {
+            return true;
+        }
+        if (sub.getParentContext() == null) {
+            return false;
+        }
+        if (sub.getParentContext().getUID().equals(context.getUID())) {
             return true;
         }
         return this.isSameOrSubContext(sub.getParentContext(), context);

--- a/billy-core/src/main/java/com/premiumminds/billy/core/persistence/dao/DAOContext.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/persistence/dao/DAOContext.java
@@ -23,6 +23,6 @@ import com.premiumminds.billy.core.services.entities.Context;
 
 public interface DAOContext extends DAO<ContextEntity> {
 
-    public boolean isSubContext(Context sub, Context context);
+    boolean isSameOrSubContext(Context sub, Context context);
 
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
@@ -63,7 +63,7 @@ public class ContextBuilderImpl<TBuilder extends ContextBuilderImpl<TBuilder, TC
         } else {
             ContextEntity c = this.daoContext.get(parentUID);
             BillyValidator.found(c, ContextBuilderImpl.LOCALIZER.getString("field.parent_context"));
-            if (!this.getTypeInstance().isNew() && this.daoContext.isSubContext(c, this.getTypeInstance())) {
+            if (!this.getTypeInstance().isNew() && this.daoContext.isSameOrSubContext(c, this.getTypeInstance())) {
                 throw new BillyRuntimeException();
             }
             this.getTypeInstance().setParentContext(c);

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
@@ -64,7 +64,7 @@ public class ContextBuilderImpl<TBuilder extends ContextBuilderImpl<TBuilder, TC
             ContextEntity c = this.daoContext.get(parentUID);
             BillyValidator.found(c, ContextBuilderImpl.LOCALIZER.getString("field.parent_context"));
             if (!this.getTypeInstance().isNew() && this.daoContext.isSameOrSubContext(c, this.getTypeInstance())) {
-                throw new BillyRuntimeException();
+                throw new BillyRuntimeException("Can't set Parent Context on old instance, itself or sub context");
             }
             this.getTypeInstance().setParentContext(c);
         }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
@@ -258,7 +258,7 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (t.getValidTo() == null || DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryBuilder.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryBuilder.java
@@ -61,8 +61,8 @@ public class TestGenericInvoiceEntryBuilder extends AbstractTest {
         Mockito.when(this.getInstance(DAOProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																		   Matchers.any(Context.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryOperations.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryOperations.java
@@ -64,12 +64,12 @@ public class TestGenericInvoiceEntryOperations extends AbstractTest {
         Mockito.when(this.getInstance(DAOGenericInvoiceEntry.class).getEntityInstance())
                 .thenReturn(new MockGenericInvoiceEntryEntity());
 
-        Mockito.when(this.getInstance(DAOContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																		   Matchers.any(Context.class))).thenReturn(true);
 
         Mockito.when(this.getInstance(DAOGenericInvoice.class).getEntityInstance()).thenReturn(this.invoiceMock);
-        Mockito.when(this.getInstance(DAOContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																		   Matchers.any(Context.class))).thenReturn(true);
         Mockito.when(this.getInstance(DAOGenericInvoice.class).get(Matchers.any(UID.class)))
                 .thenReturn(this.invoiceMock);
         Mockito.when(this.getInstance(DAOProduct.class).get(Matchers.any(UID.class)))

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceOperations.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceOperations.java
@@ -66,8 +66,8 @@ public class TestGenericInvoiceOperations extends AbstractTest {
 
         Mockito.when(this.getInstance(DAOGenericInvoice.class).getEntityInstance())
                 .thenReturn(new MockGenericInvoiceEntity());
-        Mockito.when(this.getInstance(DAOContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																		   Matchers.any(Context.class))).thenReturn(true);
 
         this.mockCustomerEntity =
                 this.createMockEntity(MockCustomerEntity.class, TestGenericInvoiceOperations.CUSTOMER_YML);

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public class FRManualEntryBuilderImpl<TBuilder extends FRManualEntryBuilderImpl<
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class FRManualInvoiceEntryBuilderImpl<TBuilder extends FRManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/persistence/FRRegionContextPersistenceService.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/persistence/FRRegionContextPersistenceService.java
@@ -95,7 +95,7 @@ public class FRRegionContextPersistenceService implements PersistenceService<FRR
 
                 @Override
                 public Boolean runTransaction() throws Exception {
-                    return FRRegionContextPersistenceService.this.daoRegionContext.isSubContext(child, parent);
+                    return FRRegionContextPersistenceService.this.daoRegionContext.isSameOrSubContext(child, parent);
                 }
 
             }.execute();

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRCreditNoteEntryBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRCreditNoteEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestFRCreditNoteEntryBuilder extends FRAbstractTest {
         Mockito.when(this.getInstance(DAOFRProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((FRProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockInvoiceEntity);
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRCreditReceiptEntryBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRCreditReceiptEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestFRCreditReceiptEntryBuilder extends FRAbstractTest {
         Mockito.when(this.getInstance(DAOFRProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((FRProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockReceiptEntity);
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRGenericInvoiceEntryBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRGenericInvoiceEntryBuilder.java
@@ -63,8 +63,8 @@ public class TestFRGenericInvoiceEntryBuilder extends FRAbstractTest {
         Mockito.when(this.getInstance(DAOFRProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((FRProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSubContext(Matchers.any(FRRegionContext.class),
-                Matchers.any(FRRegionContext.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSameOrSubContext(Matchers.any(FRRegionContext.class),
+																				   Matchers.any(FRRegionContext.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRInvoiceEntryBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRInvoiceEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestFRInvoiceEntryBuilder extends FRAbstractTest {
         Mockito.when(this.getInstance(DAOFRProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((FRProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRReceiptEntryBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRReceiptEntryBuilder.java
@@ -61,8 +61,8 @@ public class TestFRReceiptEntryBuilder extends FRAbstractTest {
         Mockito.when(this.getInstance(DAOFRProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((FRProductEntity) mockEntry.getProduct());
 
-        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOFRRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mockEntry.getDocumentReferences().add(mockReceipt);
 

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
@@ -74,7 +74,7 @@ public abstract class PTManualEntryBuilderImpl<TBuilder extends PTManualEntryBui
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/persistence/PTRegionContextPersistenceService.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/persistence/PTRegionContextPersistenceService.java
@@ -95,7 +95,7 @@ public class PTRegionContextPersistenceService implements PersistenceService<PTR
 
                 @Override
                 public Boolean runTransaction() throws Exception {
-                    return PTRegionContextPersistenceService.this.daoRegionContext.isSubContext(child, parent);
+                    return PTRegionContextPersistenceService.this.daoRegionContext.isSameOrSubContext(child, parent);
                 }
 
             }.execute();

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTCreditNoteEntryBuilder.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTCreditNoteEntryBuilder.java
@@ -62,7 +62,7 @@ public class TestPTCreditNoteEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(Context.class),
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
                 Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockInvoiceEntity);

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
@@ -63,7 +63,7 @@ public class TestPTGenericInvoiceEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(PTRegionContext.class),
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(PTRegionContext.class),
                 Matchers.any(PTRegionContext.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTInvoiceEntryBuilder.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTInvoiceEntryBuilder.java
@@ -62,7 +62,7 @@ public class TestPTInvoiceEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(Context.class),
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
                 Matchers.any(Context.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public abstract class PTManualEntryBuilderImpl<TBuilder extends PTManualEntryBui
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/persistence/PTRegionContextPersistenceService.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/persistence/PTRegionContextPersistenceService.java
@@ -95,7 +95,7 @@ public class PTRegionContextPersistenceService implements PersistenceService<PTR
 
                 @Override
                 public Boolean runTransaction() throws Exception {
-                    return PTRegionContextPersistenceService.this.daoRegionContext.isSubContext(child, parent);
+                    return PTRegionContextPersistenceService.this.daoRegionContext.isSameOrSubContext(child, parent);
                 }
 
             }.execute();

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTCreditNoteEntryBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTCreditNoteEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestPTCreditNoteEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockInvoiceEntity);
 

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
@@ -63,8 +63,8 @@ public class TestPTGenericInvoiceEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(PTRegionContext.class),
-                Matchers.any(PTRegionContext.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(PTRegionContext.class),
+																				   Matchers.any(PTRegionContext.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTInvoiceEntryBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTInvoiceEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestPTInvoiceEntryBuilder extends PTAbstractTest {
         Mockito.when(this.getInstance(DAOPTProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((PTProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public class ESManualEntryBuilderImpl<TBuilder extends ESManualEntryBuilderImpl<
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class ESManualInvoiceEntryBuilderImpl<TBuilder extends ESManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/persistence/ESRegionContextPersistenceService.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/persistence/ESRegionContextPersistenceService.java
@@ -95,7 +95,7 @@ public class ESRegionContextPersistenceService implements PersistenceService<ESR
 
                 @Override
                 public Boolean runTransaction() throws Exception {
-                    return ESRegionContextPersistenceService.this.daoRegionContext.isSubContext(child, parent);
+                    return ESRegionContextPersistenceService.this.daoRegionContext.isSameOrSubContext(child, parent);
                 }
 
             }.execute();

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESCreditNoteEntryBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESCreditNoteEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestESCreditNoteEntryBuilder extends ESAbstractTest {
         Mockito.when(this.getInstance(DAOESProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ESProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOESRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOESRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockInvoiceEntity);
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESCreditReceiptEntryBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESCreditReceiptEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestESCreditReceiptEntryBuilder extends ESAbstractTest {
         Mockito.when(this.getInstance(DAOESProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ESProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOESRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOESRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.setReference(mockReceiptEntity);
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESGenericInvoiceEntryBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESGenericInvoiceEntryBuilder.java
@@ -63,8 +63,8 @@ public class TestESGenericInvoiceEntryBuilder extends ESAbstractTest {
         Mockito.when(this.getInstance(DAOESProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ESProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOESRegionContext.class).isSubContext(Matchers.any(ESRegionContext.class),
-                Matchers.any(ESRegionContext.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOESRegionContext.class).isSameOrSubContext(Matchers.any(ESRegionContext.class),
+																				   Matchers.any(ESRegionContext.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESInvoiceEntryBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESInvoiceEntryBuilder.java
@@ -62,8 +62,8 @@ public class TestESInvoiceEntryBuilder extends ESAbstractTest {
         Mockito.when(this.getInstance(DAOESProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ESProductEntity) mock.getProduct());
 
-        Mockito.when(this.getInstance(DAOESRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOESRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mock.getDocumentReferences().add(mockInvoice);
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESReceiptEntryBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESReceiptEntryBuilder.java
@@ -61,8 +61,8 @@ public class TestESReceiptEntryBuilder extends ESAbstractTest {
         Mockito.when(this.getInstance(DAOESProduct.class).get(Matchers.any(UID.class)))
                 .thenReturn((ESProductEntity) mockEntry.getProduct());
 
-        Mockito.when(this.getInstance(DAOESRegionContext.class).isSubContext(Matchers.any(Context.class),
-                Matchers.any(Context.class))).thenReturn(true);
+        Mockito.when(this.getInstance(DAOESRegionContext.class).isSameOrSubContext(Matchers.any(Context.class),
+																				   Matchers.any(Context.class))).thenReturn(true);
 
         mockEntry.getDocumentReferences().add(mockReceipt);
 


### PR DESCRIPTION
* Rename to isSameOrSubContext
* Changes implementations preventing orphan Contexts to be successfully
compared