### PR TITLE
Corrects behavior for tax selection for a given context

### DIFF
--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
@@ -258,7 +258,7 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (t.getValidTo() == null || DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditNoteEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditNoteEntryBuilderImpl.java
@@ -77,7 +77,7 @@ public class FRManualCreditNoteEntryBuilderImpl<TBuilder extends FRManualCreditN
                 FRGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.quantity"));
         BillyValidator.mandatory(cn.getUnitOfMeasure(),
                 FRGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.unit"));
-        BillyValidator.mandatory(cn.getProduct(),
+        BillyValidator.<Object>mandatory(cn.getProduct(),
                 FRGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.product"));
         BillyValidator.notEmpty(cn.getTaxes(), FRGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));
         BillyValidator.mandatory(cn.getTaxAmount(), FRGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public class FRManualEntryBuilderImpl<TBuilder extends FRManualEntryBuilderImpl<
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class FRManualInvoiceEntryBuilderImpl<TBuilder extends FRManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRCreditNoteEntryTestUtil.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRCreditNoteEntryTestUtil.java
@@ -53,7 +53,7 @@ public class FRCreditNoteEntryTestUtil {
         FRProductEntity newProduct = (FRProductEntity) this.injector.getInstance(DAOFRProduct.class)
                 .create(new FRProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.france().allRegions();
+        this.context = this.contexts.continent().limousin();
 
         creditNoteEntryBuilder.setUnitAmount(AmountType.WITH_TAX, FRCreditNoteEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRCreditReceiptEntryTestUtil.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRCreditReceiptEntryTestUtil.java
@@ -54,7 +54,7 @@ public class FRCreditReceiptEntryTestUtil {
         FRProductEntity newProduct = (FRProductEntity) this.injector.getInstance(DAOFRProduct.class)
                 .create(new FRProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.france().allRegions();
+        this.context = this.contexts.continent().picardie();
 
         creditReceiptEntryBuilder.setUnitAmount(AmountType.WITH_TAX, FRCreditReceiptEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRInvoiceEntryTestUtil.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRInvoiceEntryTestUtil.java
@@ -54,7 +54,7 @@ public class FRInvoiceEntryTestUtil {
     public FRInvoiceEntry.Builder getInvoiceEntryBuilder(FRProductEntity product) {
         FRInvoiceEntry.Builder invoiceEntryBuilder = this.injector.getInstance(FRInvoiceEntry.Builder.class);
         FRShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.france().allRegions();
+        this.context = this.contexts.continent().bretagne();
 
         invoiceEntryBuilder.clear();
 
@@ -72,7 +72,7 @@ public class FRInvoiceEntryTestUtil {
         FRInvoiceEntry.ManualBuilder invoiceEntryBuilder =
                 this.injector.getInstance(FRInvoiceEntry.ManualBuilder.class);
         FRShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.france().allRegions();
+        this.context = this.contexts.continent().centre();
 
         invoiceEntryBuilder.clear();
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRReceiptEntryTestUtil.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRReceiptEntryTestUtil.java
@@ -49,7 +49,7 @@ public class FRReceiptEntryTestUtil {
 
     public FRReceiptEntry.Builder getReceiptEntryBuilder(FRProductEntity product) {
         FRReceiptEntry.Builder receiptEntryBuilder = this.injector.getInstance(FRReceiptEntry.Builder.class);
-        this.context = this.contexts.france().allRegions();
+        this.context = this.contexts.continent().poitouCharentes();
 
         receiptEntryBuilder.clear();
         receiptEntryBuilder.setUnitAmount(AmountType.WITH_TAX, FRReceiptEntryTestUtil.AMOUNT)

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
@@ -74,7 +74,7 @@ public abstract class PTManualEntryBuilderImpl<TBuilder extends PTManualEntryBui
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/util/PTCreditNoteEntryTestUtil.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/util/PTCreditNoteEntryTestUtil.java
@@ -53,7 +53,7 @@ public class PTCreditNoteEntryTestUtil {
         PTProductEntity newProduct = (PTProductEntity) this.injector.getInstance(DAOPTProduct.class)
                 .create(new PTProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.portugal().allRegions();
+        this.context = this.contexts.continent().lisboa();
 
         creditNoteEntryBuilder.setUnitAmount(AmountType.WITH_TAX, PTCreditNoteEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/util/PTInvoiceEntryTestUtil.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/test/util/PTInvoiceEntryTestUtil.java
@@ -54,7 +54,7 @@ public class PTInvoiceEntryTestUtil {
     public PTInvoiceEntry.Builder getInvoiceEntryBuilder(PTProductEntity product) {
         PTInvoiceEntry.Builder invoiceEntryBuilder = this.injector.getInstance(PTInvoiceEntry.Builder.class);
         PTShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.portugal().allRegions();
+        this.context = this.contexts.continent().evora();
 
         invoiceEntryBuilder.clear();
 

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public abstract class PTManualEntryBuilderImpl<TBuilder extends PTManualEntryBui
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
@@ -64,9 +64,7 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
 
     public PTInvoiceEntity getNewIssuedInvoice(String businessUID) {
         Services service = new Services(PTAbstractTest.injector);
-        PTIssuingParams parameters = new PTIssuingParamsImpl();
-
-        parameters = this.getParameters(PTPersistencyAbstractTest.DEFAULT_SERIES, "30000", "1");
+		PTIssuingParams parameters = this.getParameters(PTPersistencyAbstractTest.DEFAULT_SERIES, "30000", "1");
 
         try {
             return (PTInvoiceEntity) service.issueDocument(new PTInvoiceTestUtil(PTAbstractTest.injector)
@@ -82,9 +80,7 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
 
     public PTCreditNoteEntity getNewIssuedCreditnote(PTInvoice reference) {
         Services service = new Services(PTAbstractTest.injector);
-        PTIssuingParams parameters = new PTIssuingParamsImpl();
-
-        parameters = this.getParameters("NC", "30000", "1");
+        PTIssuingParams parameters = this.getParameters("NC", "30000", "1");
 
         try {
             return (PTCreditNoteEntity) service.issueDocument(

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
@@ -64,7 +64,7 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
 
     public PTInvoiceEntity getNewIssuedInvoice(String businessUID) {
         Services service = new Services(PTAbstractTest.injector);
-		PTIssuingParams parameters = this.getParameters(PTPersistencyAbstractTest.DEFAULT_SERIES, "30000", "1");
+        PTIssuingParams parameters = this.getParameters(PTPersistencyAbstractTest.DEFAULT_SERIES, "30000", "1");
 
         try {
             return (PTInvoiceEntity) service.issueDocument(new PTInvoiceTestUtil(PTAbstractTest.injector)

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTCreditNoteEntryTestUtil.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTCreditNoteEntryTestUtil.java
@@ -53,7 +53,7 @@ public class PTCreditNoteEntryTestUtil {
         PTProductEntity newProduct = (PTProductEntity) this.injector.getInstance(DAOPTProduct.class)
                 .create(new PTProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.portugal().allRegions();
+        this.context = this.contexts.continent().faro();
 
         creditNoteEntryBuilder.setUnitAmount(AmountType.WITH_TAX, PTCreditNoteEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTInvoiceEntryTestUtil.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTInvoiceEntryTestUtil.java
@@ -54,7 +54,7 @@ public class PTInvoiceEntryTestUtil {
     public PTInvoiceEntry.Builder getInvoiceEntryBuilder(PTProductEntity product) {
         PTInvoiceEntry.Builder invoiceEntryBuilder = this.injector.getInstance(PTInvoiceEntry.Builder.class);
         PTShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.portugal().allRegions();
+        this.context = this.contexts.continent().leiria();
 
         invoiceEntryBuilder.clear();
 
@@ -72,7 +72,7 @@ public class PTInvoiceEntryTestUtil {
         PTInvoiceEntry.ManualBuilder invoiceEntryBuilder =
                 this.injector.getInstance(PTInvoiceEntry.ManualBuilder.class);
         PTShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.portugal().allRegions();
+        this.context = this.contexts.continent().lisboa();
 
         invoiceEntryBuilder.clear();
 
@@ -103,11 +103,11 @@ public class PTInvoiceEntryTestUtil {
         if (region.equals("PT-20")) {
             product = (PTProductEntity) this.injector.getInstance(DAOPTProduct.class)
                     .create(this.product.getOtherRegionProductEntity(region));
-            this.context = this.contexts.azores().azores().getParentContext();
+            this.context = this.contexts.azores().azores();
         } else {
             product = (PTProductEntity) this.injector.getInstance(DAOPTProduct.class)
                     .create(this.product.getOtherRegionProductEntity(region));
-            this.context = this.contexts.madeira().madeira().getParentContext();
+            this.context = this.contexts.madeira().madeira();
         }
 
         PTInvoiceEntry.Builder invoiceEntryBuilder = this.injector.getInstance(PTInvoiceEntry.Builder.class);

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
@@ -69,7 +69,7 @@ public class ESManualEntryBuilderImpl<TBuilder extends ESManualEntryBuilderImpl<
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
@@ -63,7 +63,7 @@ public class ESManualInvoiceEntryBuilderImpl<TBuilder extends ESManualInvoiceEnt
     protected void validateValues() throws BillyValidationException {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
-            if (this.daoContext.isSameOrSubContext(t.getContext(), this.context)) {
+            if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
                 Date taxDate = e.getTaxPointDate() == null ? new Date() : e.getTaxPointDate();
                 if (DateUtils.isSameDay(t.getValidTo(), taxDate) || t.getValidTo().after(taxDate)) {
                     e.getTaxes().add(t);

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESCreditNoteEntryTestUtil.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESCreditNoteEntryTestUtil.java
@@ -53,7 +53,7 @@ public class ESCreditNoteEntryTestUtil {
         ESProductEntity newProduct = (ESProductEntity) this.injector.getInstance(DAOESProduct.class)
                 .create(new ESProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.spain().allRegions();
+        this.context = this.contexts.continent().albacete();
 
         creditNoteEntryBuilder.setUnitAmount(AmountType.WITH_TAX, ESCreditNoteEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESCreditReceiptEntryTestUtil.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESCreditReceiptEntryTestUtil.java
@@ -54,7 +54,7 @@ public class ESCreditReceiptEntryTestUtil {
         ESProductEntity newProduct = (ESProductEntity) this.injector.getInstance(DAOESProduct.class)
                 .create(new ESProductTestUtil(this.injector).getProductEntity());
 
-        this.context = this.contexts.spain().allRegions();
+        this.context = this.contexts.continent().almeria();
 
         creditReceiptEntryBuilder.setUnitAmount(AmountType.WITH_TAX, ESCreditReceiptEntryTestUtil.AMOUNT)
                 .setTaxPointDate(new Date()).setDescription(newProduct.getDescription())

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESInvoiceEntryTestUtil.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESInvoiceEntryTestUtil.java
@@ -54,7 +54,7 @@ public class ESInvoiceEntryTestUtil {
     public ESInvoiceEntry.Builder getInvoiceEntryBuilder(ESProductEntity product) {
         ESInvoiceEntry.Builder invoiceEntryBuilder = this.injector.getInstance(ESInvoiceEntry.Builder.class);
         ESShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.spain().allRegions();
+        this.context = this.contexts.continent().madrid();
 
         invoiceEntryBuilder.clear();
 
@@ -72,7 +72,7 @@ public class ESInvoiceEntryTestUtil {
         ESInvoiceEntry.ManualBuilder invoiceEntryBuilder =
                 this.injector.getInstance(ESInvoiceEntry.ManualBuilder.class);
         ESShippingPoint.Builder originBuilder = this.shippingPoint.getShippingPointBuilder();
-        this.context = this.contexts.spain().allRegions();
+        this.context = this.contexts.continent().barcelona();
 
         invoiceEntryBuilder.clear();
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESReceiptEntryTestUtil.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESReceiptEntryTestUtil.java
@@ -49,7 +49,7 @@ public class ESReceiptEntryTestUtil {
 
     public ESReceiptEntry.Builder getReceiptEntryBuilder(ESProductEntity product) {
         ESReceiptEntry.Builder receiptEntryBuilder = this.injector.getInstance(ESReceiptEntry.Builder.class);
-        this.context = this.contexts.spain().allRegions();
+        this.context = this.contexts.continent().asturias();
 
         receiptEntryBuilder.clear();
         receiptEntryBuilder.setUnitAmount(AmountType.WITH_TAX, ESReceiptEntryTestUtil.AMOUNT)


### PR DESCRIPTION
- Applies taxes available for entry context and parent contexts instead of other way around
- Corrects tests to have billing documents invoiced in specific context instead of parent context