### PR TITLE
Adds export SAFT methods without certificate number

### DIFF
--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/PTSAFTFileGenerator.java
@@ -37,13 +37,15 @@ public class PTSAFTFileGenerator {
 
 	@Inject
 	private com.premiumminds.billy.portugal.services.export.saftpt.v1_04_01.PTSAFTFileGenerator saftGenV1_04_01;
-	
+
 	public static enum SAFTVersion {
 		CURRENT, V10201, V10301, V10401
 	}
 
 	/**
 	 * Constructs a new SAFT a.k.a. AuditFile
+	 *
+	 * @deprecated Use the overloaded method instead
 	 *
 	 * @param targetStream the target stream
 	 * @param businessEntity the company
@@ -55,6 +57,7 @@ public class PTSAFTFileGenerator {
 	 *
 	 * @throws SAFTPTExportException when export exception occurs
 	 */
+	@Deprecated
 	public void generateSAFTFile(final OutputStream targetStream,
 			final PTBusinessEntity businessEntity,
 			final PTApplicationEntity application,
@@ -62,20 +65,42 @@ public class PTSAFTFileGenerator {
 			final Date toDate,
 			final SAFTVersion version) throws SAFTPTExportException {
 
-		switch (version) {
-		case V10201:
-			saftGenV1_02_01.generateSAFTFile(targetStream, businessEntity, application, certificateNumber, fromDate, toDate);
-			return;
-			
-		case V10301:
-			saftGenV1_03_01.generateSAFTFile(targetStream, businessEntity, application, certificateNumber, fromDate, toDate);
-			return;
+		this.generateSAFTFile(targetStream, businessEntity, application, fromDate,toDate, version);
+	}
 
-		case V10401:
-		case CURRENT:
-		default:
-			saftGenV1_04_01.generateSAFTFile(targetStream, businessEntity, application, certificateNumber, fromDate, toDate);
-			return;
+	/**
+	 * Constructs a new SAFT a.k.a. AuditFile
+	 *
+	 * @param targetStream the target stream
+	 * @param businessEntity the company
+	 * @param application the application
+	 * @param fromDate the date from when the saft will be generated
+	 * @param toDate the date until when the saft will be generated
+	 * @param version the SAFT version
+	 *
+	 * @throws SAFTPTExportException when export exception occurs
+	 */
+	public void generateSAFTFile(final OutputStream targetStream,
+								 final PTBusinessEntity businessEntity,
+								 final PTApplicationEntity application,
+								 final Date fromDate,
+								 final Date toDate,
+								 final SAFTVersion version) throws SAFTPTExportException {
+
+		switch (version) {
+			case V10201:
+				saftGenV1_02_01.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+				return;
+
+			case V10301:
+				saftGenV1_03_01.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+				return;
+
+			case V10401:
+			case CURRENT:
+			default:
+				saftGenV1_04_01.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+				return;
 		}
 
 	}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -190,32 +190,45 @@ public class PTSAFTFileGenerator {
         }
     }
 
+	/**
+	 * Constructs a new SAFT a.k.a. AuditFile
+	 *
+	 * @deprecated Use the overloaded method instead
+	 *
+	 * @param targetStream
+	 *
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
+	 * @return the SAFT for that business entity, given lists of customers,
+	 *         products, taxes and financial documents; depends on a period of
+	 *         time
+	 * @throws SAFTPTExportException
+	 */
+	@Deprecated
+	public void generateSAFTFile(final OutputStream targetStream, final PTBusinessEntity businessEntity,
+								 final PTApplicationEntity application, final String certificateNumber, final Date fromDate,
+								 final Date toDate) throws SAFTPTExportException {
+		this.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+	}
+
     /**
      * Constructs a new SAFT a.k.a. AuditFile
      *
      * @param targetStream
      *
-     * @param businessEntity
-     *        - the company
-     * @param application
-     * @param certificateNumber
-     * @param fromDate
-     * @param toDate
-     * @param daoCustomer
-     * @param daoSupplier
-     * @param daoProduct
-     * @param daoPTTax
-     * @param daoPTRegionContext
-     * @param daoPTInvoice
-     * @param daoPTSimpleInvoice
-     * @param daoPTCreditNote
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
      * @return the SAFT for that business entity, given lists of customers,
      *         products, taxes and financial documents; depends on a period of
      *         time
      * @throws SAFTPTExportException
      */
     public void generateSAFTFile(final OutputStream targetStream, final PTBusinessEntity businessEntity,
-            final PTApplicationEntity application, final String certificateNumber, final Date fromDate,
+            final PTApplicationEntity application, final Date fromDate,
             final Date toDate) throws SAFTPTExportException {
 
         try {
@@ -226,7 +239,7 @@ public class PTSAFTFileGenerator {
                     AuditFile SAFTFile = new AuditFile();
 
                     /* HEADER */
-                    Header hdr = PTSAFTFileGenerator.this.generateHeader(businessEntity, application, certificateNumber,
+                    Header hdr = PTSAFTFileGenerator.this.generateHeader(businessEntity, application,
                             fromDate, toDate);
                     SAFTFile.setHeader(hdr);
 
@@ -337,7 +350,7 @@ public class PTSAFTFileGenerator {
      * @throws InvalidContactTypeException
      */
     private Header generateHeader(PTBusinessEntity businessEntity, PTApplicationEntity application,
-            String certificateNumber, Date startDate, Date endDate)
+            Date startDate, Date endDate)
             throws DatatypeConfigurationException, RequiredFieldNotFoundException, InvalidContactTypeException {
         this.context = "Header.";
 
@@ -369,7 +382,8 @@ public class PTSAFTFileGenerator {
         hdr.setProductCompanyTaxID(this.validateString("ProductCompanyTaxID",
                 application.getDeveloperCompanyTaxIdentifier(), this.MAX_LENGTH_20, true));
         hdr.setSoftwareCertificateNumber(
-                this.validateBigInteger("SoftwareCertificateNumber", certificateNumber, this.MAX_LENGTH_255, true));
+                this.validateBigInteger("SoftwareCertificateNumber", application.getSoftwareCertificationNumber().toString(),
+					this.MAX_LENGTH_255, true));
         hdr.setProductID(this.validateString("ProductID",
                 application.getName() + "/" + application.getDeveloperCompanyName(), this.MAX_LENGTH_255, true));
         hdr.setProductVersion(
@@ -628,7 +642,6 @@ public class PTSAFTFileGenerator {
      *
      * @param document
      *        - can be an invoice, simple invoice or credit note
-     * @param documentType
      * @return an instance of Invoice (represents a financial document in the
      *         SAFT XML context)
      *

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -192,32 +192,45 @@ public class PTSAFTFileGenerator {
         }
     }
 
+	/**
+	 * Constructs a new SAFT a.k.a. AuditFile
+	 *
+	 * @deprecated Use the overloaded method instead
+	 *
+	 * @param targetStream
+	 *
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
+	 * @return the SAFT for that business entity, given lists of customers,
+	 *         products, taxes and financial documents; depends on a period of
+	 *         time
+	 * @throws SAFTPTExportException
+	 */
+	@Deprecated
+	public AuditFile generateSAFTFile(final OutputStream targetStream, final PTBusinessEntity businessEntity,
+									  final PTApplicationEntity application, final String certificateNumber, final Date fromDate,
+									  final Date toDate) throws SAFTPTExportException {
+		return this.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+	}
+
     /**
      * Constructs a new SAFT a.k.a. AuditFile
      *
      * @param targetStream
      *
-     * @param businessEntity
-     *        - the company
-     * @param application
-     * @param certificateNumber
-     * @param fromDate
-     * @param toDate
-     * @param daoCustomer
-     * @param daoSupplier
-     * @param daoProduct
-     * @param daoPTTax
-     * @param daoPTRegionContext
-     * @param daoPTInvoice
-     * @param daoPTSimpleInvoice
-     * @param daoPTCreditNote
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
      * @return the SAFT for that business entity, given lists of customers,
      *         products, taxes and financial documents; depends on a period of
      *         time
      * @throws SAFTPTExportException
      */
     public AuditFile generateSAFTFile(final OutputStream targetStream, final PTBusinessEntity businessEntity,
-            final PTApplicationEntity application, final String certificateNumber, final Date fromDate,
+            final PTApplicationEntity application, final Date fromDate,
             final Date toDate) throws SAFTPTExportException {
 
         try {
@@ -228,7 +241,7 @@ public class PTSAFTFileGenerator {
                     AuditFile SAFTFile = new AuditFile();
 
                     /* HEADER */
-                    Header hdr = PTSAFTFileGenerator.this.generateHeader(businessEntity, application, certificateNumber,
+                    Header hdr = PTSAFTFileGenerator.this.generateHeader(businessEntity, application,
                             fromDate, toDate);
                     SAFTFile.setHeader(hdr);
 
@@ -339,7 +352,7 @@ public class PTSAFTFileGenerator {
      * @throws InvalidContactTypeException
      */
     private Header generateHeader(PTBusinessEntity businessEntity, PTApplicationEntity application,
-            String certificateNumber, Date startDate, Date endDate)
+            Date startDate, Date endDate)
             throws DatatypeConfigurationException, RequiredFieldNotFoundException, InvalidContactTypeException {
         this.context = "Header.";
 
@@ -371,7 +384,8 @@ public class PTSAFTFileGenerator {
         hdr.setProductCompanyTaxID(this.validateString("ProductCompanyTaxID",
                 application.getDeveloperCompanyTaxIdentifier(), this.MAX_LENGTH_20, true));
         hdr.setSoftwareCertificateNumber(
-                this.validateBigInteger("SoftwareCertificateNumber", certificateNumber, this.MAX_LENGTH_255, true));
+                this.validateBigInteger("SoftwareCertificateNumber", application.getSoftwareCertificationNumber().toString(),
+					this.MAX_LENGTH_255, true));
         hdr.setProductID(this.validateString("ProductID",
                 application.getName() + "/" + application.getDeveloperCompanyName(), this.MAX_LENGTH_255, true));
         hdr.setProductVersion(
@@ -630,7 +644,6 @@ public class PTSAFTFileGenerator {
      *
      * @param document
      *        - can be an invoice, simple invoice or credit note
-     * @param documentType
      * @return an instance of Invoice (represents a financial document in the
      *         SAFT XML context)
      *

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -114,9 +114,9 @@ import com.premiumminds.billy.portugal.services.export.saftpt.v1_04_01.schema.So
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_04_01.schema.SourceDocuments.SalesInvoices.Invoice.Line;
 
 public class PTSAFTFileGenerator {
-	
+
 	private static final Logger log = LoggerFactory.getLogger(Config.class);
-	
+
 	private Config						config					= null;
 	private JAXBContext					jaxbContext;
 	private Marshaller					marshaller;
@@ -199,23 +199,40 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Constructs a new SAFT a.k.a. AuditFile
-	 * 
+	 *
+	 * @deprecated Use the overloaded method instead
+	 *
 	 * @param targetStream
-	 * 
-	 * @param businessEntity
-	 *            - the company
-	 * @param application
-	 * @param certificateNumber
-	 * @param fromDate
-	 * @param toDate
-	 * @param daoCustomer
-	 * @param daoSupplier
-	 * @param daoProduct
-	 * @param daoPTTax
-	 * @param daoPTRegionContext
-	 * @param daoPTInvoice
-	 * @param daoPTSimpleInvoice
-	 * @param daoPTCreditNote
+	 *
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param certificateNumber - ignored. It uses the softwareCertificationNumber in application
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
+	 * @return the SAFT for that business entity, given lists of customers,
+	 *         products, taxes and financial documents; depends on a period of
+	 *         time
+	 * @throws SAFTPTExportException
+	 */
+	@Deprecated
+	public AuditFile generateSAFTFile(final OutputStream targetStream,
+									  final PTBusinessEntity businessEntity,
+									  final PTApplicationEntity application,
+									  final String certificateNumber,
+									  final Date fromDate,
+									  final Date toDate) throws SAFTPTExportException {
+		return this.generateSAFTFile(targetStream, businessEntity, application, fromDate, toDate);
+	}
+
+	/**
+	 * Constructs a new SAFT a.k.a. AuditFile
+	 *
+	 * @param targetStream
+	 *
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param fromDate - the period for the SAFT file
+	 * @param toDate - the period for the SAFT file
 	 * @return the SAFT for that business entity, given lists of customers,
 	 *         products, taxes and financial documents; depends on a period of
 	 *         time
@@ -224,7 +241,7 @@ public class PTSAFTFileGenerator {
 	public AuditFile generateSAFTFile(final OutputStream targetStream,
 			final PTBusinessEntity businessEntity,
 			final PTApplicationEntity application,
-			final String certificateNumber, final Date fromDate,
+			final Date fromDate,
 			final Date toDate) throws SAFTPTExportException {
 
 		try {
@@ -236,7 +253,7 @@ public class PTSAFTFileGenerator {
 
 					/* HEADER */
 					Header hdr = PTSAFTFileGenerator.this.generateHeader(
-							businessEntity, application, certificateNumber,
+							businessEntity, application,
 							fromDate, toDate);
 					SAFTFile.setHeader(hdr);
 
@@ -328,7 +345,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the SAFT XML File
-	 * 
+	 *
 	 * @param auditFile
 	 *            that will be exported
 	 * @param targetStream
@@ -347,11 +364,11 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the Header of SAFT file (Table 1)
-	 * 
-	 * @param businessEntity
-	 *            - the company
-	 * @param startDate
-	 *            , endDate - the period for the SAFT file
+	 *
+	 * @param businessEntity - the company
+	 * @param application - the software
+	 * @param startDate - the period for the SAFT file
+	 * @param endDate - the period for the SAFT file
 	 * @return the Header
 	 * @throws DatatypeConfigurationException
 	 *             - problems with dates
@@ -360,7 +377,7 @@ public class PTSAFTFileGenerator {
 	 * @throws InvalidContactTypeException
 	 */
 	private Header generateHeader(PTBusinessEntity businessEntity,
-			PTApplicationEntity application, String certificateNumber,
+			PTApplicationEntity application,
 			Date startDate, Date endDate)
 		throws DatatypeConfigurationException, RequiredFieldNotFoundException,
 		InvalidContactTypeException {
@@ -402,7 +419,7 @@ public class PTSAFTFileGenerator {
 				application.getDeveloperCompanyTaxIdentifier(),
 				this.MAX_LENGTH_20, true));
 		hdr.setSoftwareCertificateNumber(this.validateBigInteger(
-				"SoftwareCertificateNumber", certificateNumber,
+				"SoftwareCertificateNumber", application.getSoftwareCertificationNumber().toString(),
 				this.MAX_LENGTH_255, true));
 		hdr.setProductID(this.validateString("ProductID", application.getName()
 				+ "/" + application.getDeveloperCompanyName(),
@@ -419,7 +436,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates an instance of Customer to be inserted in the table 2.2
 	 * (Customer)
-	 * 
+	 *
 	 * @param customerEntity
 	 *            - the customer
 	 * @return an instance of Customer
@@ -470,7 +487,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates an instance of Supplier to be inserted in the table 2.3
 	 * (Supplier)
-	 * 
+	 *
 	 * @param supplierEntity
 	 *            - the supplier
 	 * @return an instance of Supplier
@@ -526,7 +543,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates an instance of Product to be inserted in the table 2.4
 	 * (Product)
-	 * 
+	 *
 	 * @param productEntity
 	 *            - the product/service
 	 * @return an instance of Product
@@ -565,7 +582,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the TaxTable of SAFT file (Table 2.5)
-	 * 
+	 *
 	 * @param taxEntities
 	 *            - the taxes to be inserted in this table
 	 * @return
@@ -615,7 +632,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the SourceDocuments of SAFT file (Table 4)
-	 * 
+	 *
 	 * @param invoices
 	 *            - list of invoices
 	 * @param simpleInvoices
@@ -690,13 +707,12 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates a financial document that will be inserted in the
 	 * SourceDocuments table
-	 * 
+	 *
 	 * @param document
 	 *            - can be an invoice, simple invoice or credit note
-	 * @param documentType
 	 * @return an instance of Invoice (represents a financial document in the
 	 *         SAFT XML context)
-	 * 
+	 *
 	 * @throws DatatypeConfigurationException
 	 * @throws RequiredFieldNotFoundException
 	 * @throws InvalidDocumentTypeException
@@ -727,8 +743,8 @@ public class PTSAFTFileGenerator {
 				MAX_LENGTH_2, true));
 		saftInv.setInvoiceDate(formatDate(document.getDate()));
 		saftInv.setSpecialRegimes(
-				getSpecialRegimes(document.isSelfBilled(), 
-						document.isCashVATEndorser(), 
+				getSpecialRegimes(document.isSelfBilled(),
+						document.isCashVATEndorser(),
 						document.isThirdPartyBilled()));
 		saftInv.setSourceID(validateString("InvoiceSourceID",
 				document.getSourceId(), MAX_LENGTH_30, true));
@@ -796,7 +812,7 @@ public class PTSAFTFileGenerator {
 	 * Process a financial document to generate its DocumentTotals and the
 	 * document's entries to generate the table Line in the Invoice instance of
 	 * SAFT File
-	 * 
+	 *
 	 * @param saftInvoice
 	 *            - instance of Invoice (representation of financial document in
 	 *            SAFT XML context)
@@ -805,7 +821,7 @@ public class PTSAFTFileGenerator {
 	 * @param isCredit
 	 *            - to distinguish between invoices/simple invoices (credit
 	 *            transactions) and credit notes (debit transaction)
-	 * 
+	 *
 	 * @throws RequiredFieldNotFoundException
 	 * @throws DatatypeConfigurationException
 	 * @throws InvalidDocumentTypeException
@@ -922,10 +938,10 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the field OrderReferences (4.1.4.18.2) of document entry
-	 * 
+	 *
 	 * @param entry
 	 * @return an instance of OrderReferences
-	 * 
+	 *
 	 * @throws RequiredFieldNotFoundException
 	 * @throws DatatypeConfigurationException
 	 */
@@ -950,7 +966,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the field References (4.1.4.18.9) of document entry
-	 * 
+	 *
 	 * @param entry
 	 * @param document
 	 * @return an instance of References
@@ -998,7 +1014,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Constructs an instance of ShippingPointStructure needed in the
 	 * construction of a SAFT Invoice
-	 * 
+	 *
 	 * @param deliveryID
 	 *            - the id of delivery/origin
 	 * @param deliveryDate
@@ -1029,7 +1045,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates the field Currency (4.1.4.19.4) of DocumentTotals of a SAFT
 	 * Invoice
-	 * 
+	 *
 	 * @param document
 	 * @param isCredit
 	 * @return
@@ -1052,7 +1068,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Generates the field Settlement (4.1.4.19.5) of DocumentTotals of a SAFT
 	 * Invoice
-	 * 
+	 *
 	 * @param document
 	 * @return
 	 * @throws RequiredFieldNotFoundException
@@ -1087,7 +1103,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the DocumentTotals (4.1.4.19) of a SAFT Invoice
-	 * 
+	 *
 	 * @param document
 	 * @param isCredit
 	 * @return
@@ -1142,7 +1158,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Generates the InvoiceType (4.1.4.7) of a SAFT Invoice
-	 * 
+	 *
 	 * @param document
 	 * @return
 	 * @throws InvalidInvoiceTypeException
@@ -1172,7 +1188,7 @@ public class PTSAFTFileGenerator {
 	 *************/
 	/**
 	 * Sets the main information about the Customer
-	 * 
+	 *
 	 * @param customer
 	 * @param customerID
 	 * @param customerFinancialID
@@ -1203,7 +1219,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Converts the document state to an acronym according to the SAFT file
 	 * rules
-	 * 
+	 *
 	 * @param document
 	 * @return
 	 * @throws InvalidDocumentStateException
@@ -1266,7 +1282,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Converts the payment mechanism to an acronym according to the SAFT file
 	 * rules
-	 * 
+	 *
 	 * @param pm
 	 * @return
 	 * @throws InvalidPaymentMechanismException
@@ -1307,7 +1323,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Constructs an AddressStructures that is used in almost every fields of
 	 * SAFT file that represent addresses
-	 * 
+	 *
 	 * @param addressEntity
 	 * @return
 	 * @throws RequiredFieldNotFoundException
@@ -1351,7 +1367,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Constructs a specific AddressStructurePT that is only used in the Header
 	 * of the SAFT File
-	 * 
+	 *
 	 * @param addressEntity
 	 * @return
 	 * @throws RequiredFieldNotFoundException
@@ -1392,7 +1408,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Constructs an SupplierAddressStructures that is used in the Supplier of
 	 * the SAFT file
-	 * 
+	 *
 	 * @param addressEntity
 	 * @return
 	 * @throws RequiredFieldNotFoundException
@@ -1434,7 +1450,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Converts the ISO code of a region to the code defined in the SAFT file
 	 * rules
-	 * 
+	 *
 	 * @param regionCode
 	 * @return
 	 */
@@ -1453,7 +1469,7 @@ public class PTSAFTFileGenerator {
 	 ************/
 	/**
 	 * Sets the contacts of a company
-	 * 
+	 *
 	 * @param hdr
 	 * @param contacts
 	 *            - the company's list of contacts
@@ -1494,7 +1510,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Sets the contacts of a customer
-	 * 
+	 *
 	 * @param customer
 	 * @param contacts
 	 *            - the customer's list of contacts
@@ -1533,7 +1549,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Sets the contacts of a supplier
-	 * 
+	 *
 	 * @param supplier
 	 * @param contacts
 	 *            - the supplier's list of contacts
@@ -1575,7 +1591,7 @@ public class PTSAFTFileGenerator {
 	 ************/
 	/**
 	 * Converts the product type to an acronym according to the SAFT file rules
-	 * 
+	 *
 	 * @param type
 	 * @return
 	 * @throws InvalidProductTypeException
@@ -1601,7 +1617,7 @@ public class PTSAFTFileGenerator {
 	 *********/
 	/**
 	 * Converts the tax type to an acronym according to the SAFT file rules
-	 * 
+	 *
 	 * @param entity
 	 * @return
 	 * @throws InvalidTaxTypeException
@@ -1627,7 +1643,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Validates a string, considering the max length of that field that will be
 	 * assigned and if that field is required
-	 * 
+	 *
 	 * @param field
 	 * @param str
 	 * @param maxLength
@@ -1651,7 +1667,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Validates an integer, considering the max length of that field that will
 	 * be assigned and if that field is required
-	 * 
+	 *
 	 * @param field
 	 * @param str
 	 *            - a string that represents an integer
@@ -1669,7 +1685,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Validates a BigInteger, considering the max length of that field that
 	 * will be assigned and if that field is required
-	 * 
+	 *
 	 * @param field
 	 * @param str
 	 *            - a string that represents a BigInteger
@@ -1688,7 +1704,7 @@ public class PTSAFTFileGenerator {
 	/**
 	 * Validates a decimal number, limiting it to 2 decimal places and rounding
 	 * int
-	 * 
+	 *
 	 * @param bd
 	 * @return
 	 */
@@ -1698,7 +1714,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Gets the today's date
-	 * 
+	 *
 	 * @return
 	 * @throws DatatypeConfigurationException
 	 */
@@ -1709,7 +1725,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Returns a date in the format YYYY-MM-dd
-	 * 
+	 *
 	 * @param date
 	 * @return
 	 * @throws DatatypeConfigurationException
@@ -1726,7 +1742,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Returns a datetime in the format YYYY-MM-ddThh-mm-ss
-	 * 
+	 *
 	 * @param date
 	 * @return
 	 * @throws DatatypeConfigurationException
@@ -1745,7 +1761,7 @@ public class PTSAFTFileGenerator {
 
 	/**
 	 * Returns a field (the month or the year) of a date
-	 * 
+	 *
 	 * @param date
 	 * @param field
 	 * @return

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/SAFTs.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/SAFTs.java
@@ -38,33 +38,45 @@ import com.premiumminds.billy.portugal.services.export.saftpt.PTSAFTFileGenerato
 
 public class SAFTs {
 
-    private static final String TMP_SAFT = System.getProperty("java.io.tmpdir") + "/saft.xml";
-    private final Injector injector;
-    private final PTSAFTFileGenerator generator;
+	private static final String TMP_SAFT = System.getProperty("java.io.tmpdir") + "/saft.xml";
+	private final Injector injector;
+	private final PTSAFTFileGenerator generator;
 
-    public SAFTs(Injector injector) {
-        this.injector = injector;
-        this.generator = this.getInstance(PTSAFTFileGenerator.class);
-    }
+	public SAFTs(Injector injector) {
+		this.injector = injector;
+		this.generator = this.getInstance(PTSAFTFileGenerator.class);
+	}
 
-    public InputStream export(UID uidApplication, UID uidBusiness, String certificateNumber, Date from, Date to,
-            SAFTVersion version) throws SAFTPTExportException, IOException {
-        return this.export(uidApplication, uidBusiness, certificateNumber, from, to, SAFTs.TMP_SAFT, version);
-    }
+	public InputStream export(UID uidApplication, UID uidBusiness, Date from, Date to,
+							  SAFTVersion version) throws SAFTPTExportException, IOException {
+		return this.export(uidApplication, uidBusiness, from, to, SAFTs.TMP_SAFT, version);
+	}
 
-    public InputStream export(UID uidApplication, UID uidBusiness, String certificateNumber, Date from, Date to,
-            String resultPath, SAFTVersion version) throws SAFTPTExportException, IOException {
-        File outputFile = new File(resultPath);
-        OutputStream oStream = new FileOutputStream(outputFile);
+	public InputStream export(UID uidApplication, UID uidBusiness, Date from, Date to,
+							  String resultPath, SAFTVersion version) throws SAFTPTExportException, IOException {
+		File outputFile = new File(resultPath);
+		OutputStream oStream = new FileOutputStream(outputFile);
 
-        this.generator.generateSAFTFile(oStream, this.getInstance(DAOPTBusiness.class).get(uidBusiness),
-                this.getInstance(DAOPTApplication.class).get(uidApplication), certificateNumber, from, to, version);
-        IOUtils.closeQuietly(oStream);
-        return new FileInputStream(outputFile);
-    }
+		this.generator.generateSAFTFile(oStream, this.getInstance(DAOPTBusiness.class).get(uidBusiness),
+			this.getInstance(DAOPTApplication.class).get(uidApplication), from, to, version);
+		IOUtils.closeQuietly(oStream);
+		return new FileInputStream(outputFile);
+	}
 
-    private <T> T getInstance(Class<T> clazz) {
-        return this.injector.getInstance(clazz);
-    }
+	@Deprecated
+	public InputStream export(UID uidApplication, UID uidBusiness, String certificateNumber, Date from, Date to,
+							  SAFTVersion version) throws SAFTPTExportException, IOException {
+		return this.export(uidApplication, uidBusiness, from, to, SAFTs.TMP_SAFT, version);
+	}
+
+	@Deprecated
+	public InputStream export(UID uidApplication, UID uidBusiness, String certificateNumber, Date from, Date to,
+							  String resultPath, SAFTVersion version) throws SAFTPTExportException, IOException {
+		return this.export(uidApplication, uidBusiness, from, to, resultPath, version);
+	}
+
+	private <T> T getInstance(Class<T> clazz) {
+		return this.injector.getInstance(clazz);
+	}
 
 }


### PR DESCRIPTION
Deprecates current methods, for later removal.
The certificate number is redundant with application instance, which
contains that information.