### PR TITLE
Fixes wrong PT NIF validation

### DIFF
--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/util/PTFinancialValidator.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/util/PTFinancialValidator.java
@@ -18,6 +18,9 @@
  */
 package com.premiumminds.billy.portugal.util;
 
+import java.util.List;
+
+import com.google.common.collect.Lists;
 import com.premiumminds.billy.core.util.FinancialValidator;
 
 public class PTFinancialValidator extends FinancialValidator {
@@ -35,10 +38,23 @@ public class PTFinancialValidator extends FinancialValidator {
             return false;
         }
 
-        // Fist digit must be 1, 2, 5, 6, 8 or 9
-        char firstDigit = this.financialID.charAt(0);
-        String validChars = "125689";
-        if (validChars.indexOf(firstDigit) == -1) {
+        List<Character> firstDigits = Lists.charactersOf("123568");
+        boolean validFirstDigit = firstDigits
+                .stream()
+                .map(c -> financialID.charAt(0) == c).filter(b -> b)
+                .findAny()
+                .orElse(false);
+
+        List<String> firstDoubleDigits =
+                Lists.newArrayList("45", "70", "71", "72", "74", "75", "77", "79", "90", "91", "98", "99");
+        boolean validDoubleDigits = firstDoubleDigits
+                .stream()
+                .map(c -> financialID.substring(0,  2).equals(c))
+                .filter(b -> b)
+                .findAny()
+                .orElse(false);
+
+        if(!validFirstDigit && !validDoubleDigits){
             return false;
         }
 

--- a/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/util/PTFinancialValidatorTest.java
+++ b/billy-portugal-ebean/src/test/java/com/premiumminds/billy/portugal/util/PTFinancialValidatorTest.java
@@ -1,0 +1,45 @@
+package com.premiumminds.billy.portugal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PTFinancialValidatorTest {
+
+    @Test
+    public void testValidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("241250609");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testValidNifUsual() {
+        PTFinancialValidator validator = new PTFinancialValidator("123456789");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testValidNif0term() {
+        PTFinancialValidator validator = new PTFinancialValidator("504426290");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testInvalidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("124456789");
+        assertFalse(validator.isValid());
+    }
+
+    @Test
+    public void testAnotherInvalidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("505646780");
+        assertFalse(validator.isValid());
+    }
+
+    @Test
+    public void testValidDoubleDigit() {
+        PTFinancialValidator validator = new PTFinancialValidator("451234561");
+        assertTrue(validator.isValid());
+    }
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/PTFinancialValidator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/PTFinancialValidator.java
@@ -18,6 +18,9 @@
  */
 package com.premiumminds.billy.portugal.util;
 
+import java.util.List;
+
+import com.google.common.collect.Lists;
 import com.premiumminds.billy.core.util.FinancialValidator;
 
 public class PTFinancialValidator extends FinancialValidator {
@@ -35,10 +38,23 @@ public class PTFinancialValidator extends FinancialValidator {
             return false;
         }
 
-        // Fist digit must be 1, 2, 5, 6, 8 or 9
-        char firstDigit = this.financialID.charAt(0);
-        String validChars = "125689";
-        if (validChars.indexOf(firstDigit) == -1) {
+        List<Character> firstDigits = Lists.charactersOf("123568");
+        boolean validFirstDigit = firstDigits
+                .stream()
+                .map(c -> financialID.charAt(0) == c).filter(b -> b)
+                .findAny()
+                .orElse(false);
+
+        List<String> firstDoubleDigits =
+                Lists.newArrayList("45", "70", "71", "72", "74", "75", "77", "79", "90", "91", "98", "99");
+        boolean validDoubleDigits = firstDoubleDigits
+                .stream()
+                .map(c -> financialID.substring(0,  2).equals(c))
+                .filter(b -> b)
+                .findAny()
+                .orElse(false);
+
+        if(!validFirstDigit && !validDoubleDigits){
             return false;
         }
 

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/util/PTFinancialValidatorTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/util/PTFinancialValidatorTest.java
@@ -1,0 +1,45 @@
+package com.premiumminds.billy.portugal.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PTFinancialValidatorTest {
+
+    @Test
+    public void testValidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("241250609");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testValidNifUsual() {
+        PTFinancialValidator validator = new PTFinancialValidator("123456789");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testValidNif0term() {
+        PTFinancialValidator validator = new PTFinancialValidator("504426290");
+        assertTrue(validator.isValid());
+    }
+
+    @Test
+    public void testInvalidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("124456789");
+        assertFalse(validator.isValid());
+    }
+
+    @Test
+    public void testAnotherInvalidNif() {
+        PTFinancialValidator validator = new PTFinancialValidator("505646780");
+        assertFalse(validator.isValid());
+    }
+
+    @Test
+    public void testValidDoubleDigit() {
+        PTFinancialValidator validator = new PTFinancialValidator("451234561");
+        assertTrue(validator.isValid());
+    }
+
+}


### PR DESCRIPTION
The list of first digits includes more combinations than what is
used in code.
See:
[Número de identificação fiscal](https://pt.wikipedia.org/wiki/N%C3%BAmero_de_identifica%C3%A7%C3%A3o_fiscal#Constitui%C3%A7%C3%A3o_e_interpreta%C3%A7%C3%A3o)