### PR TITLE
Replace old and abandoned bouncycastle bcprov-jdk16

### DIFF
--- a/billy-france/pom.xml
+++ b/billy-france/pom.xml
@@ -124,8 +124,7 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
-			<version>1.46</version>
+			<artifactId>bcpkix-jdk15on</artifactId>
 		</dependency>
 
 		<!-- SnakeYaml -->

--- a/billy-france/src/main/java/com/premiumminds/billy/france/util/KeyGenerator.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/util/KeyGenerator.java
@@ -28,7 +28,9 @@ import java.security.Security;
 
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +73,13 @@ public class KeyGenerator {
     }
 
     private KeyPair getKeyPair() {
-        PEMReader pemReader = new PEMReader(new StringReader(this.getKeyFromFile()));
+        PEMParser pemReader = new PEMParser(new StringReader(this.getKeyFromFile()));
         KeyPair pair = null;
 
         try {
-            pair = (KeyPair) pemReader.readObject();
+            PEMKeyPair pemKeyPair = (PEMKeyPair) pemReader.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            pair = converter.getKeyPair(pemKeyPair);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);
         } finally {

--- a/billy-portugal-ebean/pom.xml
+++ b/billy-portugal-ebean/pom.xml
@@ -102,8 +102,7 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
-			<version>1.46</version>
+			<artifactId>bcpkix-jdk15on</artifactId>
 		</dependency>
 
 		<!-- SnakeYaml -->

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
@@ -28,7 +28,9 @@ import java.security.Security;
 
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +73,13 @@ public class KeyGenerator {
     }
 
     private KeyPair getKeyPair() {
-        PEMReader pemReader = new PEMReader(new StringReader(this.getKeyFromFile()));
+        PEMParser pemReader = new PEMParser(new StringReader(this.getKeyFromFile()));
         KeyPair pair = null;
 
         try {
-            pair = (KeyPair) pemReader.readObject();
+            PEMKeyPair pemKeyPair = (PEMKeyPair) pemReader.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            pair = converter.getKeyPair(pemKeyPair);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);
         } finally {

--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -125,8 +125,7 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
-			<version>1.46</version>
+			<artifactId>bcpkix-jdk15on</artifactId>
 		</dependency>
 
 		<!-- SnakeYaml -->

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
@@ -28,7 +28,9 @@ import java.security.Security;
 
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +73,13 @@ public class KeyGenerator {
     }
 
     private KeyPair getKeyPair() {
-        PEMReader pemReader = new PEMReader(new StringReader(this.getKeyFromFile()));
+        PEMParser pemReader = new PEMParser(new StringReader(this.getKeyFromFile()));
         KeyPair pair = null;
 
         try {
-            pair = (KeyPair) pemReader.readObject();
+            PEMKeyPair pemKeyPair = (PEMKeyPair) pemReader.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            pair = converter.getKeyPair(pemKeyPair);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);
         } finally {

--- a/billy-spain/pom.xml
+++ b/billy-spain/pom.xml
@@ -124,8 +124,7 @@
 
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk16</artifactId>
-			<version>1.46</version>
+			<artifactId>bcpkix-jdk15on</artifactId>
 		</dependency>
 
 		<!-- SnakeYaml -->

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/util/KeyGenerator.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/util/KeyGenerator.java
@@ -28,7 +28,9 @@ import java.security.Security;
 
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMReader;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,11 +73,13 @@ public class KeyGenerator {
     }
 
     private KeyPair getKeyPair() {
-        PEMReader pemReader = new PEMReader(new StringReader(this.getKeyFromFile()));
+        PEMParser pemReader = new PEMParser(new StringReader(this.getKeyFromFile()));
         KeyPair pair = null;
 
         try {
-            pair = (KeyPair) pemReader.readObject();
+            PEMKeyPair pemKeyPair = (PEMKeyPair) pemReader.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            pair = converter.getKeyPair(pemKeyPair);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);
         } finally {

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,13 @@
 				<version>${guice.version}</version>
 			</dependency>
 
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk15on</artifactId>
+				<version>1.67</version>
+			</dependency>
+
+
 			<!-- SnakeYaml -->
 			<dependency>
 				<groupId>org.yaml</groupId>


### PR DESCRIPTION
bcprov-jdk16 was to support jdk 1.6 and was abandoned in favor of
bcprov-jdk15on which support from java 1.5 and later versions

openssl support was moved to auxiliary lib bcpkix.
PEMReader was removed in 1.50.

See:
https://stackoverflow.com/questions/53344297/bouncy-castle-need-of-bcprov-jdk15-and-bcprov-jdk16