### PR TITLE
Changes saft.xml export from WINDOWS-1252 to UTF-8

### DIFF
--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -123,7 +123,7 @@ public class PTSAFTFileGenerator {
     private String context = null;
     private String optionalParam;
 
-    private static final String FILE_ENCODING = "WINDOWS-1252";
+    private static final String FILE_ENCODING = "UTF-8";
 
     private final int MAX_LENGTH_1 = 1;
     private final int MAX_LENGTH_2 = 2;
@@ -313,8 +313,8 @@ public class PTSAFTFileGenerator {
      */
     private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
         try {
-            this.marshaller.setProperty("jaxb.encoding", PTSAFTFileGenerator.FILE_ENCODING);
-            this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+            this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+            this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             this.marshaller.marshal(auditFile, targetStream);
 
         } catch (Exception e) {

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -125,7 +125,7 @@ public class PTSAFTFileGenerator {
     private String context = null;
     private String optionalParam;
 
-    private static final String FILE_ENCODING = "WINDOWS-1252";
+    private static final String FILE_ENCODING = "UTF-8";
 
     private final int MAX_LENGTH_1 = 1;
     private final int MAX_LENGTH_2 = 2;
@@ -315,8 +315,8 @@ public class PTSAFTFileGenerator {
      */
     private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
         try {
-            this.marshaller.setProperty("jaxb.encoding", PTSAFTFileGenerator.FILE_ENCODING);
-            this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+            this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+            this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             this.marshaller.marshal(auditFile, targetStream);
 
         } catch (Exception e) {

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -126,7 +126,7 @@ public class PTSAFTFileGenerator {
 	private String						context					= null;
 	private String						optionalParam;
 
-	private static final String			FILE_ENCODING			= "WINDOWS-1252";
+	private static final String			FILE_ENCODING			= "UTF-8";
 
 	private final int					MAX_LENGTH_1			= 1;
 	private final int					MAX_LENGTH_2			= 2;
@@ -358,9 +358,8 @@ public class PTSAFTFileGenerator {
 	 */
 	private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
 		try {
-			this.marshaller.setProperty("jaxb.encoding",
-					PTSAFTFileGenerator.FILE_ENCODING);
-			this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+			this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+			this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 			this.marshaller.marshal(auditFile, targetStream);
 
 		} catch (Exception e) {

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -123,7 +123,7 @@ public class PTSAFTFileGenerator {
     private String context = null;
     private String optionalParam;
 
-    private static final String FILE_ENCODING = "WINDOWS-1252";
+    private static final String FILE_ENCODING = "UTF-8";
 
     private final int MAX_LENGTH_1 = 1;
     private final int MAX_LENGTH_2 = 2;
@@ -326,8 +326,8 @@ public class PTSAFTFileGenerator {
      */
     private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
         try {
-            this.marshaller.setProperty("jaxb.encoding", PTSAFTFileGenerator.FILE_ENCODING);
-            this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+            this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+            this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             this.marshaller.marshal(auditFile, targetStream);
 
         } catch (Exception e) {

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -125,7 +125,7 @@ public class PTSAFTFileGenerator {
     private String context = null;
     private String optionalParam;
 
-    private static final String FILE_ENCODING = "WINDOWS-1252";
+    private static final String FILE_ENCODING = "UTF-8";
 
     private final int MAX_LENGTH_1 = 1;
     private final int MAX_LENGTH_2 = 2;
@@ -328,8 +328,8 @@ public class PTSAFTFileGenerator {
      */
     private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
         try {
-            this.marshaller.setProperty("jaxb.encoding", PTSAFTFileGenerator.FILE_ENCODING);
-            this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+            this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+            this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
             this.marshaller.marshal(auditFile, targetStream);
 
         } catch (Exception e) {

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -126,7 +126,7 @@ public class PTSAFTFileGenerator {
 	private String						context					= null;
 	private String						optionalParam;
 
-	private static final String			FILE_ENCODING			= "WINDOWS-1252";
+	private static final String			FILE_ENCODING			= "UTF-8";
 
 	private final int					MAX_LENGTH_1			= 1;
 	private final int					MAX_LENGTH_2			= 2;
@@ -358,9 +358,8 @@ public class PTSAFTFileGenerator {
 	 */
 	private void exportSAFTFile(AuditFile auditFile, OutputStream targetStream) {
 		try {
-			this.marshaller.setProperty("jaxb.encoding",
-					PTSAFTFileGenerator.FILE_ENCODING);
-			this.marshaller.setProperty("jaxb.formatted.output", Boolean.TRUE);
+			this.marshaller.setProperty(Marshaller.JAXB_ENCODING, FILE_ENCODING);
+			this.marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
 			this.marshaller.marshal(auditFile, targetStream);
 
 		} catch (Exception e) {


### PR DESCRIPTION
UTF-8 is capable of handling a much larger character set than Windows-1252