### PR TITLE
Change Hibernate Validator groupid and bump to 6.1.6.Final

### DIFF
--- a/billy-core-jpa/pom.xml
+++ b/billy-core-jpa/pom.xml
@@ -47,8 +47,8 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>org.hibernate</groupId>
-		    <artifactId>hibernate-validator</artifactId>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.el</groupId>

--- a/billy-core/pom.xml
+++ b/billy-core/pom.xml
@@ -60,7 +60,7 @@
 			<version>2.0.1.Final</version>
 		</dependency>
 		<dependency>
-			<groupId>org.hibernate</groupId>
+			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 		<dependency>

--- a/billy-france/pom.xml
+++ b/billy-france/pom.xml
@@ -61,8 +61,8 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>org.hibernate</groupId>
-		    <artifactId>hibernate-validator</artifactId>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.el</groupId>

--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -62,8 +62,8 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>org.hibernate</groupId>
-		    <artifactId>hibernate-validator</artifactId>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.el</groupId>

--- a/billy-spain/pom.xml
+++ b/billy-spain/pom.xml
@@ -61,8 +61,8 @@
 		</dependency>
 
 		<dependency>
-		    <groupId>org.hibernate</groupId>
-		    <artifactId>hibernate-validator</artifactId>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.el</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.hibernate</groupId>
+				<groupId>org.hibernate.validator</groupId>
 				<artifactId>hibernate-validator</artifactId>
-				<version>5.4.3.Final</version>
+				<version>6.1.6.Final</version>
 				<scope>provided</scope>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
The group id of Hibernate Validator has changed from org.hibernate to
org.hibernate.validator. Refer to the artifacts via
org.hibernate.validator:hibernate-validator:6.0.0.Final,
org.hibernate.validator:hibernate-validator-cdi:6.0.0.Final and
org.hibernate.validator:hibernate-validator-annotation-processor:6.0.0.Final,
respectively.
https://hibernate.org/validator/documentation/migration-guide/#6-1-x