### PR TITLE
Add validation to invoice number and series

### DIFF
--- a/billy-core/src/main/resources/com/premiumminds/billy/core/i18n/FieldNames.properties
+++ b/billy-core/src/main/resources/com/premiumminds/billy/core/i18n/FieldNames.properties
@@ -97,6 +97,8 @@ field.settlement_date=Settlement Date
 field.payment_mechanism=Payment Mechanism
 field.credit_or_debit=Credit or Debit
 field.clientType=Client Type
+field.documentSeries=Series
+field.documentNumber=Document Number
 
 #Generic Invoice Entry
 field.entry_shipping_origin=Shipping Origin

--- a/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
+++ b/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
@@ -104,6 +104,8 @@ field.cancelled=Annulé
 field.billed=Facturé
 field.source_billing=Source du document
 field.amount_value=Montant de la facture
+field.documentSeries=Série
+field.documentNumber=Numéro du document
 
 #Generic Invoice Entry
 field.entry_shipping_origin=Origine du transport

--- a/billy-portugal-ebean/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
+++ b/billy-portugal-ebean/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
@@ -46,7 +46,7 @@ field.bank_owner_name=Titular da Conta Bancária
 
 #Business
 field.business_context=Contexto da Empresa
-field.financial_id=Número de Identificação Fiscal da Empresa 
+field.financial_id=Número de Identificação Fiscal da Empresa
 field.business_name=Nome da Empresa
 field.commercial_name=Nome Comercial da Empresa
 field.business_website=Website da Empresa
@@ -66,7 +66,7 @@ field.website=Website
 
 #Context
 field.context_name=Nome do Contexto
-field.description=Descriçãodo Contexto
+field.description=Descrição do Contexto
 field.parent_context=Contexto Pai
 field.region_code=Código da Região
 
@@ -107,6 +107,8 @@ field.cancelled=Cancelado
 field.billed=Faturado
 field.source_billing=Origem do Documento
 field.amount_value=Valor da Fatura
+field.documentSeries=Série de Faturação
+field.documentNumber=Número do Documento
 
 #Generic Invoice Entry
 field.entry_shipping_origin=Origem do Transporte

--- a/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
+++ b/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
@@ -96,7 +96,7 @@ field.batch_id=Identificador do Lote
 field.transaction=Identificador da Transação
 field.receipt_number=Número do Recibo
 field.entry=Linha
-field.settlement_description=Descriçãodo Acordo
+field.settlement_description=Descrição do Acordo
 field.discount=Desconto
 field.settlement_date=Data do Acordo
 field.payment_mechanism=Forma de Pagamento
@@ -107,6 +107,8 @@ field.billed=Faturado
 field.source_billing=Origem do Documento
 field.amount_value=Valor da Fatura
 field.clientType=Tipo de Cliente
+field.documentSeries=Série de Faturação
+field.documentNumber=Número do Documento
 
 #Generic Invoice Entry
 field.entry_shipping_origin=Origem do Transporte

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTInvoiceIssuingHandler.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTInvoiceIssuingHandler.java
@@ -97,7 +97,7 @@ public class TestPTInvoiceIssuingHandler extends PTDocumentAbstractTest {
     @Test
     public void testIssuedInvoiceDifferentSeries() throws DocumentIssuingException {
         Integer nextNumber = 1;
-        String newSeries = "NEW_SERIES";
+        String newSeries = "NEWSERIES";
 
         PTGenericInvoiceEntity newInvoice =
                 this.newInvoice(TestPTInvoiceIssuingHandler.DEFAULT_TYPE, TestPTInvoiceIssuingHandler.SOURCE_BILLING);
@@ -121,7 +121,7 @@ public class TestPTInvoiceIssuingHandler extends PTDocumentAbstractTest {
      */
     @Test
     public void testIssuedInvoiceFailure() throws DocumentIssuingException {
-        String series = "NEW_SERIES";
+        String series = "NEWSERIES";
 
         PTGenericInvoiceEntity invoice =
                 this.newInvoice(TestPTInvoiceIssuingHandler.DEFAULT_TYPE, TestPTInvoiceIssuingHandler.SOURCE_BILLING);
@@ -136,6 +136,16 @@ public class TestPTInvoiceIssuingHandler extends PTDocumentAbstractTest {
 
         Assertions.assertThrows(InvalidInvoiceTypeException.class, () -> this.issueNewInvoice(newHandler, diffentTypeInvoice, series));
     }
+
+	@Test
+	public void testIssuedInvoiceFailureWithInvalidSeriesAndInvoiceNumber() throws DocumentIssuingException {
+		String series = "NEW_SERIES";
+
+		PTGenericInvoiceEntity invoice =
+			this.newInvoice(TestPTInvoiceIssuingHandler.DEFAULT_TYPE, TestPTInvoiceIssuingHandler.SOURCE_BILLING);
+
+		Assertions.assertThrows(DocumentIssuingException.class, () -> this.issueNewInvoice(this.handler, invoice, series));
+	}
 
     @Test
     public void testIssuedInvoiceSameSourceBilling() throws DocumentIssuingException {

--- a/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
+++ b/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
@@ -106,6 +106,8 @@ field.cancelled=Cancelado
 field.billed=Facturado
 field.source_billing=Origen del Documento
 field.amount_value=Valor de la Factura
+field.documentSeries=Serie
+field.documentNumber=Número del Documento
 
 #Generic Invoice Entry
 field.entry_shipping_origin=Origen del Transporte


### PR DESCRIPTION
É necessário adicionar uma proteccão na API do billing para não permitir ter séries de faturas que não válidas na exportação do SAFT. 

4.1.4.1 - InvoiceNo

Composto pelo código interno do documento, seguido de um espaço, seguido do identificador da série do documento, seguido de uma barra (/) e de um número sequencial do documento dentro da série.([a-zA-Z0-9./_-])+ ([a-zA-Z0-9]*/[0-9]+)

Requisitos técnicos a que se refere a al. e) do artigo 3.º da Portaria n.º 363/2010, de 23 de junho, com a redação dada pela Portaria n.º 22-A/2012, de 24 de janeiro. - http://www.desafioinformatico.pt/DocumentosCertificacao2012/OficioCirculado_500002012.pdf