### PR TITLE
Replaces deprecated hibernate-entitymanager with hibernate-core

### DIFF
--- a/billy-core-jpa/pom.xml
+++ b/billy-core-jpa/pom.xml
@@ -38,7 +38,7 @@
 		<!-- PERSISTENCE -->
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-france/pom.xml
+++ b/billy-france/pom.xml
@@ -52,7 +52,7 @@
 		<!-- PERSISTENCE -->
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -53,7 +53,7 @@
 		<!-- PERSISTENCE -->
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/billy-spain/pom.xml
+++ b/billy-spain/pom.xml
@@ -52,7 +52,7 @@
 		<!-- PERSISTENCE -->
 		<dependency>
 			<groupId>org.hibernate</groupId>
-			<artifactId>hibernate-entitymanager</artifactId>
+			<artifactId>hibernate-core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 			<!-- PERSISTENCE -->
 			<dependency>
 				<groupId>org.hibernate</groupId>
-				<artifactId>hibernate-entitymanager</artifactId>
+				<artifactId>hibernate-core</artifactId>
 				<version>${hibernate.version}</version>
 				<scope>provided</scope>
 			</dependency>


### PR DESCRIPTION
Hibernate's JPA support has been merged into the hibernate-core module, making this hibernate-entitymanager module
obsolete.  This module will be removed in Hibernate ORM 6.0.  It is only kept here for various consumers that expect a
static set of artifact names across a number of Hibernate releases. See
https://hibernate.atlassian.net/browse/HHH-10823