### PR TITLE
Remove erroneous tax validation

### DIFF
--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
@@ -81,8 +81,7 @@ public class PTGenericInvoiceEntryBuilderImpl<TBuilder extends PTGenericInvoiceE
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));
         BillyValidator.mandatory(i.getTaxPointDate(),
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax_point_date"));
-		if(i.getTaxAmount().equals(BigDecimal.ZERO)
-			|| (i.getTaxes().stream().map(Tax::getPercentageRateValue).reduce(BigDecimal.ZERO, BigDecimal::add).equals(BigDecimal.ZERO))) {
+		if(i.getTaxAmount().equals(BigDecimal.ZERO)) {
 
 			BillyValidator.mandatory(
 				i.getTaxExemptionReason(),

--- a/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
+++ b/billy-portugal-ebean/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
@@ -81,7 +81,7 @@ public class PTGenericInvoiceEntryBuilderImpl<TBuilder extends PTGenericInvoiceE
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));
         BillyValidator.mandatory(i.getTaxPointDate(),
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax_point_date"));
-		if(i.getTaxAmount().equals(BigDecimal.ZERO)) {
+		if(i.getTaxAmount().compareTo(BigDecimal.ZERO) == 0) {
 
 			BillyValidator.mandatory(
 				i.getTaxExemptionReason(),

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
@@ -73,8 +73,7 @@ public class PTGenericInvoiceEntryBuilderImpl<TBuilder extends PTGenericInvoiceE
         BillyValidator.mandatory(i.getTaxAmount(), PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));
         BillyValidator.mandatory(i.getTaxPointDate(),
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax_point_date"));
-		if(i.getTaxAmount().equals(BigDecimal.ZERO)
-			|| (i.getTaxes().stream().map(Tax::getPercentageRateValue).reduce(BigDecimal.ZERO, BigDecimal::add).equals(BigDecimal.ZERO))) {
+		if(i.getTaxAmount().equals(BigDecimal.ZERO)) {
 
 			BillyValidator.mandatory(
 				i.getTaxExemptionCode(),

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTGenericInvoiceEntryBuilderImpl.java
@@ -73,7 +73,7 @@ public class PTGenericInvoiceEntryBuilderImpl<TBuilder extends PTGenericInvoiceE
         BillyValidator.mandatory(i.getTaxAmount(), PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax"));
         BillyValidator.mandatory(i.getTaxPointDate(),
                 PTGenericInvoiceEntryBuilderImpl.LOCALIZER.getString("field.tax_point_date"));
-		if(i.getTaxAmount().equals(BigDecimal.ZERO)) {
+		if(i.getTaxAmount().compareTo(BigDecimal.ZERO) == 0) {
 
 			BillyValidator.mandatory(
 				i.getTaxExemptionCode(),

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTGenericInvoiceEntryBuilder.java
@@ -97,6 +97,57 @@ public class TestPTGenericInvoiceEntryBuilder extends PTAbstractTest {
     }
 
 	@Test
+	public void doTestWithoutTaxes() {
+		MockPTGenericInvoiceEntryEntity mock = this.createMockEntity(MockPTGenericInvoiceEntryEntity.class,
+		TestPTGenericInvoiceEntryBuilder.PT_GENERIC_INVOICE_ENTRY_WITHOUT_TAXES_YML);
+
+		mock.currency = Currency.getInstance("EUR");
+
+		Mockito.when(this.getInstance(DAOPTGenericInvoiceEntry.class).getEntityInstance())
+				.thenReturn(new MockPTGenericInvoiceEntryEntity());
+
+		MockPTGenericInvoiceEntity mockInvoice = this.createMockEntity(MockPTGenericInvoiceEntity.class,
+		TestPTGenericInvoiceEntryBuilder.PT_GENERIC_INVOICE_WITHOUT_TAXES_YML);
+
+		Mockito.when(this.getInstance(DAOPTGenericInvoice.class).get(Mockito.any(UID.class))).thenReturn(mockInvoice);
+
+		Mockito.when(this.getInstance(DAOPTProduct.class).get(Mockito.any(UID.class)))
+				.thenReturn((PTProductEntity) mock.getProduct());
+
+		Mockito.when(this.getInstance(DAOPTRegionContext.class).isSameOrSubContext(Mockito.any(),
+		Mockito.any(PTRegionContext.class))).thenReturn(true);
+
+		mock.getDocumentReferences().add(mockInvoice);
+
+		PTGenericInvoiceEntry.Builder builder = this.getInstance(PTGenericInvoiceEntry.Builder.class);
+
+		builder.setDescription(mock.getDescription())
+				.addDocumentReferenceUID(mock.getDocumentReferences().get(0).getUID()).setQuantity(mock.getQuantity())
+				.setShippingCostsAmount(mock.getShippingCostsAmount())
+				.setUnitAmount(AmountType.WITH_TAX, mock.getUnitAmountWithTax())
+				.setUnitOfMeasure(mock.getUnitOfMeasure()).setProductUID(mock.getProduct().getUID())
+				.setTaxPointDate(mock.getTaxPointDate()).setCurrency(Currency.getInstance("EUR"))
+				.setTaxExemptionCode("M99")
+				.setTaxExemptionReason("stub");
+
+		PTGenericInvoiceEntry entry = builder.build();
+
+		if (entry.getAmountType().compareTo(AmountType.WITHOUT_TAX) == 0) {
+			Assertions.assertTrue(mock.getUnitAmountWithoutTax().compareTo(entry.getUnitAmountWithoutTax()) == 0);
+		} else {
+			Assertions.assertTrue(mock.getUnitAmountWithTax().compareTo(entry.getUnitAmountWithTax()) == 0);
+		}
+
+		Assertions.assertTrue(mock.getUnitDiscountAmount().compareTo(entry.getUnitDiscountAmount()) == 0);
+
+		Assertions.assertTrue(mock.getUnitTaxAmount().compareTo(entry.getUnitTaxAmount()) == 0);
+		Assertions.assertTrue(mock.getAmountWithTax().compareTo(entry.getAmountWithTax()) == 0);
+		Assertions.assertTrue(mock.getAmountWithoutTax().compareTo(entry.getAmountWithoutTax()) == 0);
+		Assertions.assertTrue(mock.getTaxAmount().compareTo(entry.getTaxAmount()) == 0);
+		Assertions.assertTrue(mock.getDiscountAmount().compareTo(entry.getDiscountAmount()) == 0);
+	}
+
+	@Test
 	public void doTestFailWithInvalidTaxExemptionCode() {
 		MockPTGenericInvoiceEntryEntity mock = this.createMockEntity(MockPTGenericInvoiceEntryEntity.class,
 																	 TestPTGenericInvoiceEntryBuilder.PT_GENERIC_INVOICE_ENTRY_YML);

--- a/billy-portugal/src/test/resources/yml/PTGenericInvoiceEntryWithoutTaxes.yml
+++ b/billy-portugal/src/test/resources/yml/PTGenericInvoiceEntryWithoutTaxes.yml
@@ -50,7 +50,7 @@ product : !!com.premiumminds.billy.portugal.test.fixtures.MockPTProductEntity
         value : 0
         validFrom: 2013-01-01
         validTo: 2013-12-12
-        taxRateType : PERCENTAGE
+        taxRateType : NONE
         percentageRateValue : 0
         flatRateAmount : 0
         context : !!com.premiumminds.billy.portugal.test.fixtures.MockPTRegionContextEntity
@@ -104,7 +104,7 @@ taxes:
     value : 202
     validFrom: 2013-01-02
     validTo: 2013-12-12
-    taxRateType : FLAT
+    taxRateType : NONE
     percentageRateValue : 0
     flatRateAmount : 0
     context : !!com.premiumminds.billy.portugal.test.fixtures.MockPTRegionContextEntity


### PR DESCRIPTION
The second validation wasn't taking into account FLAT RATE taxes or
 entries without taxes. In the latter case it'd throw a NullPointerException
Validating if the taxAmount is 0 should suffice
  For this we needed to fix the comparison method
  
BigDecimal's equals validate not only the value, but it's precision
 For the majority of cases they should be compared with compareTo()
(i.e. "0.00" != "0" unless compared with compareTo() which returns true)

New test for invoice entries without taxes plus a fix to a fixture