### PR TITLE
Remove javax.validation

### DIFF
--- a/billy-core-jpa/pom.xml
+++ b/billy-core-jpa/pom.xml
@@ -46,22 +46,6 @@
 			<artifactId>hibernate-envers</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.el</groupId>
-			<artifactId>jakarta.el-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.el</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- H2 -->
 		<dependency>
 			<groupId>com.h2database</groupId>

--- a/billy-core/pom.xml
+++ b/billy-core/pom.xml
@@ -54,26 +54,6 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.12.0</version>
 		</dependency>
-		<dependency>
-			<groupId>jakarta.validation</groupId>
-			<artifactId>jakarta.validation-api</artifactId>
-			<version>2.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.el</groupId>
-			<artifactId>jakarta.el-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.el</artifactId>
-			<scope>test</scope>
-		</dependency>
 
 		<!-- JUNIT -->
 		<dependency>

--- a/billy-core/src/main/java/com/premiumminds/billy/core/exceptions/BillyValidationException.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/exceptions/BillyValidationException.java
@@ -24,4 +24,8 @@ public class BillyValidationException extends BillyRuntimeException {
 
     public BillyValidationException() {
     }
+
+    public BillyValidationException(String message) {
+        super(message);
+    }
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/AbstractBuilder.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/AbstractBuilder.java
@@ -18,8 +18,6 @@
  */
 package com.premiumminds.billy.core.services.builders.impl;
 
-import javax.validation.ValidationException;
-
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.entities.BaseEntity;
 import com.premiumminds.billy.core.services.UID;
@@ -40,7 +38,7 @@ public abstract class AbstractBuilder<TBuilder extends AbstractBuilder<TBuilder,
         return (TBuilder) this;
     }
 
-    protected abstract void validateInstance() throws BillyValidationException, ValidationException;
+    protected abstract void validateInstance() throws BillyValidationException;
 
     protected <T extends TType> void setTypeInstance(T instance) {
         this.typeInstance = instance;
@@ -60,7 +58,7 @@ public abstract class AbstractBuilder<TBuilder extends AbstractBuilder<TBuilder,
         return this.getBuilder();
     }
 
-    public TType build() throws BillyValidationException, ValidationException {
+    public TType build() throws BillyValidationException {
         this.validateInstance();
         return this.getTypeInstance();
     }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ApplicationBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ApplicationBuilderImpl.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOApplication;
 import com.premiumminds.billy.core.persistence.entities.ApplicationEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
@@ -98,7 +99,7 @@ public class ApplicationBuilderImpl<TBuilder extends ApplicationBuilderImpl<TBui
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         ApplicationEntity application = this.getTypeInstance();
         BillyValidator.mandatory(application.getName(),
                 ApplicationBuilderImpl.LOCALIZER.getString("field.application_name"));

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/BankAccountBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/BankAccountBuilderImpl.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOBankAccount;
 import com.premiumminds.billy.core.persistence.entities.BankAccountEntity;
 import com.premiumminds.billy.core.services.builders.BankAccountBuilder;
@@ -69,7 +70,7 @@ public class BankAccountBuilderImpl<TBuilder extends BankAccountBuilderImpl<TBui
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         BankAccountEntity b = this.getTypeInstance();
         BillyValidator.mandatory(b.getIBANNumber(), "field.iban");
         BillyValidator.mandatory(b.getBankAccountNumber(), "field.bank_account_number");

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/BusinessBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/BusinessBuilderImpl.java
@@ -21,6 +21,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.exceptions.BillyUpdateException;
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOBusiness;
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
@@ -154,7 +155,7 @@ public class BusinessBuilderImpl<TBuilder extends BusinessBuilderImpl<TBuilder, 
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         BusinessEntity b = this.getTypeInstance();
         BillyValidator.mandatory(b.getFinancialID(), BusinessBuilderImpl.LOCALIZER.getString("field.financial_id"));
         BillyValidator.mandatory(b.getName(), BusinessBuilderImpl.LOCALIZER.getString("field.business_name"));

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContactBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContactBuilderImpl.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOContact;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.builders.ContactBuilder;
@@ -83,7 +84,7 @@ public class ContactBuilderImpl<TBuilder extends ContactBuilderImpl<TBuilder, TC
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         Contact c = this.getTypeInstance();
         BillyValidator.mandatory(c.getTelephone(), "field.contact_telephone");
         BillyValidator.mandatory(c.getName(), "field.contact_name");

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ContextBuilderImpl.java
@@ -21,6 +21,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.exceptions.BillyRuntimeException;
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
 import com.premiumminds.billy.core.persistence.entities.ContextEntity;
 import com.premiumminds.billy.core.services.UID;
@@ -72,7 +73,7 @@ public class ContextBuilderImpl<TBuilder extends ContextBuilderImpl<TBuilder, TC
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         ContextEntity c = this.getTypeInstance();
         BillyValidator.mandatory(c.getName(), ContextBuilderImpl.LOCALIZER.getString("field.context_name"));
         BillyValidator.mandatory(c.getDescription(), ContextBuilderImpl.LOCALIZER.getString("field.description"));

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/CustomerBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/CustomerBuilderImpl.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOContact;
 import com.premiumminds.billy.core.persistence.dao.DAOCustomer;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
@@ -133,7 +134,7 @@ public class CustomerBuilderImpl<TBuilder extends CustomerBuilderImpl<TBuilder, 
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         CustomerEntity c = this.getTypeInstance();
         BillyValidator.mandatory(c.getName(), CustomerBuilderImpl.LOCALIZER.getString("field.customer_name"));
         BillyValidator.mandatory(c.getTaxRegistrationNumber(),

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceBuilderImpl.java
@@ -23,10 +23,9 @@ import java.math.MathContext;
 import java.util.Currency;
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.Validate;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.AbstractDAOGenericInvoice;
 import com.premiumminds.billy.core.persistence.dao.DAOBusiness;
 import com.premiumminds.billy.core.persistence.dao.DAOCustomer;
@@ -269,7 +268,7 @@ public class GenericInvoiceBuilderImpl<TBuilder extends GenericInvoiceBuilderImp
 
     @NotOnUpdate
     @Override
-    protected void validateInstance() throws ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         GenericInvoiceEntity i = this.getTypeInstance();
         if (i.isSelfBilled() != null) {
             i.setSelfBilled(false);
@@ -289,7 +288,7 @@ public class GenericInvoiceBuilderImpl<TBuilder extends GenericInvoiceBuilderImp
         }
     }
 
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
 
         GenericInvoiceEntity i = this.getTypeInstance();
         i.setCurrency(Currency.getInstance("EUR")); // FIXME: Hardcoded currency.

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
@@ -24,11 +24,11 @@ import java.util.Currency;
 import java.util.Date;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.time.DateUtils;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.AbstractDAOGenericInvoice;
 import com.premiumminds.billy.core.persistence.dao.AbstractDAOGenericInvoiceEntry;
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
@@ -233,7 +233,7 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
     }
 
     @Override
-    protected void validateInstance() throws ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         this.validateValues();
 
         GenericInvoiceEntry i = this.getTypeInstance();
@@ -252,7 +252,7 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
         }
     }
 
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         MathContext mc = BillyMathContext.get();
 
         GenericInvoiceEntryEntity e = this.getTypeInstance();
@@ -266,7 +266,7 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
             }
         }
         if (e.getTaxes().isEmpty()) {
-            throw new ValidationException(
+            throw new BillyValidationException(
                     GenericInvoiceEntryBuilderImpl.LOCALIZER.getString("exception.invalid_taxes"));
         }
 

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/PaymentBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/PaymentBuilderImpl.java
@@ -21,7 +21,6 @@ package com.premiumminds.billy.core.services.builders.impl;
 import java.util.Date;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOPayment;
@@ -59,7 +58,7 @@ public class PaymentBuilderImpl<TBuilder extends PaymentBuilderImpl<TBuilder, TP
     }
 
     @Override
-    protected void validateInstance() throws BillyValidationException, ValidationException {
+    protected void validateInstance() throws BillyValidationException {
     }
 
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ProductBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/ProductBuilderImpl.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.services.builders.impl;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOProduct;
 import com.premiumminds.billy.core.persistence.dao.DAOTax;
 import com.premiumminds.billy.core.persistence.entities.ProductEntity;
@@ -107,7 +108,7 @@ public class ProductBuilderImpl<TBuilder extends ProductBuilderImpl<TBuilder, TP
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         Product p = this.getTypeInstance();
         BillyValidator.mandatory(p.getProductCode(), ProductBuilderImpl.LOCALIZER.getString("field.product_code"));
         BillyValidator.mandatory(p.getDescription(), ProductBuilderImpl.LOCALIZER.getString("field.description"));

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/TaxBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/TaxBuilderImpl.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 
 import org.apache.commons.lang3.Validate;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
 import com.premiumminds.billy.core.persistence.dao.DAOTax;
 import com.premiumminds.billy.core.persistence.entities.ContextEntity;
@@ -133,7 +134,7 @@ public class TaxBuilderImpl<TBuilder extends TaxBuilderImpl<TBuilder, TTax>, TTa
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         Tax t = this.getTypeInstance();
         /*BillyValidator.mandatory(t.getDescription(),
                 TaxBuilderImpl.LOCALIZER.getString("field.tax_description"));

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/TicketBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/TicketBuilderImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.persistence.dao.DAOTicket;
 import com.premiumminds.billy.core.persistence.entities.TicketEntity;
 import com.premiumminds.billy.core.services.UID;
@@ -51,7 +52,7 @@ public class TicketBuilderImpl<TBuilder extends TicketBuilderImpl<TBuilder, TTic
     }
 
     @Override
-    protected void validateInstance() throws javax.validation.ValidationException {
+    protected void validateInstance() throws BillyValidationException {
 
     }
 

--- a/billy-core/src/main/java/com/premiumminds/billy/core/util/BillyValidator.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/util/BillyValidator.java
@@ -19,13 +19,6 @@
 package com.premiumminds.billy.core.util;
 
 import java.util.Collection;
-import java.util.Set;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.ValidationException;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
 
 import org.apache.commons.lang3.Validate;
 
@@ -33,38 +26,10 @@ public class BillyValidator extends Validate {
 
     private static BillyValidator instance = new BillyValidator();
 
-    private Localizer localizer;
-    private ValidatorFactory factory;
-    private Validator validator;
+    private final Localizer localizer;
 
     private BillyValidator() {
         this.localizer = new Localizer("com/premiumminds/billy/core/i18n/Validation");
-        this.factory = Validation.buildDefaultValidatorFactory();
-        this.validator = this.factory.getValidator();
-    }
-
-    public static void validateBeans(Object... objects) throws ValidationException {
-        StringBuilder builder = new StringBuilder();
-        boolean valid = true;
-
-        for (Object o : objects) {
-            Set<ConstraintViolation<Object>> violations = BillyValidator.instance.validator.validate(o);
-            if (!violations.isEmpty()) {
-                valid = false;
-                builder.append("There was an exception while validating instance of ");
-                builder.append(o.getClass().getCanonicalName());
-                builder.append('\n');
-
-                for (ConstraintViolation<Object> v : violations) {
-                    builder.append('\n');
-                    builder.append(v.getPropertyPath() + " - " + v.getMessage());
-                }
-            }
-        }
-
-        if (!valid) {
-            throw new ValidationException(builder.toString());
-        }
     }
 
     public static <T> T mandatory(T o, String fieldName) {

--- a/billy-france/pom.xml
+++ b/billy-france/pom.xml
@@ -60,22 +60,6 @@
 			<artifactId>hibernate-envers</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.el</groupId>
-			<artifactId>jakarta.el-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.el</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Query DSL -->
 		<dependency>
 			<groupId>com.querydsl</groupId>

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRApplicationBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRApplicationBuilderImpl.java
@@ -19,8 +19,8 @@
 package com.premiumminds.billy.france.services.builders.impl;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.ApplicationBuilderImpl;
 import com.premiumminds.billy.core.util.Localizer;
 import com.premiumminds.billy.france.persistence.dao.DAOFRApplication;
@@ -44,7 +44,7 @@ public class FRApplicationBuilderImpl<TBuilder extends FRApplicationBuilderImpl<
     }
 
     @Override
-    protected void validateInstance() throws ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
     }
 

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.france.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Currency;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.Validate;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -75,7 +73,7 @@ public abstract class FRManualBuilderImpl<TBuilder extends FRManualBuilderImpl<T
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntity i = this.getTypeInstance();
         i.setCurrency(Currency.getInstance("EUR"));
 

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualEntryBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.france.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -65,7 +63,7 @@ public class FRManualEntryBuilderImpl<TBuilder extends FRManualEntryBuilderImpl<
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualInvoiceEntryBuilderImpl.java
@@ -20,8 +20,6 @@ package com.premiumminds.billy.france.services.builders.impl;
 
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -60,7 +58,7 @@ public class FRManualInvoiceEntryBuilderImpl<TBuilder extends FRManualInvoiceEnt
     }
 
     @Override
-    protected void validateValues() throws BillyValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
             if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
@@ -71,7 +69,7 @@ public class FRManualInvoiceEntryBuilderImpl<TBuilder extends FRManualInvoiceEnt
             }
         }
         if (e.getTaxes().isEmpty()) {
-            throw new ValidationException(
+            throw new BillyValidationException(
                     GenericInvoiceEntryBuilderImpl.LOCALIZER.getString("exception.invalid_taxes"));
         }
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRPaymentBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRPaymentBuilderImpl.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.PaymentBuilderImpl;
@@ -70,7 +69,7 @@ public class FRPaymentBuilderImpl<TBuilder extends FRPaymentBuilderImpl<TBuilder
     }
 
     @Override
-    protected void validateInstance() throws BillyValidationException, ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
         FRPaymentEntity p = this.getTypeInstance();
         BillyValidator.mandatory(p.getPaymentAmount(),

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRReceiptBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRReceiptBuilderImpl.java
@@ -18,8 +18,6 @@
  */
 package com.premiumminds.billy.france.services.builders.impl;
 
-import javax.validation.ValidationException;
-
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice.CreditOrDebit;
 import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.france.persistence.dao.AbstractDAOFRGenericInvoice;
@@ -47,7 +45,7 @@ public class FRReceiptBuilderImpl<TBuilder extends FRReceiptBuilderImpl<TBuilder
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         FRReceiptEntity i = this.getTypeInstance();
         i.setCreditOrDebit(CreditOrDebit.CREDIT);
         super.validateValues();

--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -61,22 +61,6 @@
 			<artifactId>hibernate-envers</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.el</groupId>
-			<artifactId>jakarta.el-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.el</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Query DSL -->
 		<dependency>
 			<groupId>com.querydsl</groupId>

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTApplicationBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTApplicationBuilderImpl.java
@@ -21,8 +21,8 @@ package com.premiumminds.billy.portugal.services.builders.impl;
 import java.net.URL;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.ApplicationBuilderImpl;
 import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.core.util.Localizer;
@@ -61,7 +61,7 @@ public class PTApplicationBuilderImpl<TBuilder extends PTApplicationBuilderImpl<
     }
 
     @Override
-    protected void validateInstance() throws ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
         PTApplicationEntity c = this.getTypeInstance();
         BillyValidator.mandatory(c.getSoftwareCertificationNumber(),

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.portugal.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Currency;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.Validate;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -89,7 +87,7 @@ public abstract class PTManualBuilderImpl<TBuilder extends PTManualBuilderImpl<T
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntity i = this.getTypeInstance();
         i.setCurrency(Currency.getInstance("EUR"));
 

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualEntryBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.portugal.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -65,7 +63,7 @@ public abstract class PTManualEntryBuilderImpl<TBuilder extends PTManualEntryBui
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualInvoiceEntryBuilderImpl.java
@@ -20,8 +20,6 @@ package com.premiumminds.billy.portugal.services.builders.impl;
 
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -60,7 +58,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
     }
 
     @Override
-    protected void validateValues() throws BillyValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
             if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
@@ -71,7 +69,7 @@ public class PTManualInvoiceEntryBuilderImpl<TBuilder extends PTManualInvoiceEnt
             }
         }
         if (e.getTaxes().isEmpty()) {
-            throw new ValidationException(
+            throw new BillyValidationException(
                     GenericInvoiceEntryBuilderImpl.LOCALIZER.getString("exception.invalid_taxes"));
         }
     }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTPaymentBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTPaymentBuilderImpl.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.PaymentBuilderImpl;
@@ -70,7 +69,7 @@ public class PTPaymentBuilderImpl<TBuilder extends PTPaymentBuilderImpl<TBuilder
     }
 
     @Override
-    protected void validateInstance() throws BillyValidationException, ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
         PTPaymentEntity p = this.getTypeInstance();
         BillyValidator.mandatory(p.getPaymentAmount(),

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/GenerateHash.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/GenerateHash.java
@@ -24,17 +24,15 @@ import java.security.PublicKey;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import javax.validation.constraints.NotNull;
-
 import com.premiumminds.billy.core.services.exceptions.DocumentIssuingException;
 import com.premiumminds.billy.core.util.BillyMathContext;
 import com.premiumminds.billy.portugal.services.certification.CertificationManager;
 
 public class GenerateHash {
 
-    public static String generateHash(@NotNull PrivateKey privateKey, @NotNull PublicKey publicKey,
-            @NotNull Date invoiceDate, @NotNull Date systemEntryDate, @NotNull String invoiceNumber,
-            @NotNull BigDecimal grossTotal, String previousInvoiceHash) throws DocumentIssuingException {
+    public static String generateHash(PrivateKey privateKey, PublicKey publicKey,
+            Date invoiceDate, Date systemEntryDate, String invoiceNumber,
+            BigDecimal grossTotal, String previousInvoiceHash) throws DocumentIssuingException {
 
         try {
             String sourceString = GenerateHash.generateSourceHash(invoiceDate, systemEntryDate, invoiceNumber,

--- a/billy-spain/pom.xml
+++ b/billy-spain/pom.xml
@@ -60,22 +60,6 @@
 			<artifactId>hibernate-envers</artifactId>
 		</dependency>
 
-		<dependency>
-			<groupId>org.hibernate.validator</groupId>
-			<artifactId>hibernate-validator</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.el</groupId>
-			<artifactId>jakarta.el-api</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.glassfish</groupId>
-			<artifactId>jakarta.el</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 		<!-- Query DSL -->
 		<dependency>
 			<groupId>com.querydsl</groupId>

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESApplicationBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESApplicationBuilderImpl.java
@@ -19,8 +19,8 @@
 package com.premiumminds.billy.spain.services.builders.impl;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
+import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.ApplicationBuilderImpl;
 import com.premiumminds.billy.core.util.Localizer;
 import com.premiumminds.billy.spain.persistence.dao.DAOESApplication;
@@ -44,7 +44,7 @@ public class ESApplicationBuilderImpl<TBuilder extends ESApplicationBuilderImpl<
     }
 
     @Override
-    protected void validateInstance() throws ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
     }
 

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.spain.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Currency;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.Validate;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -75,7 +73,7 @@ public abstract class ESManualBuilderImpl<TBuilder extends ESManualBuilderImpl<T
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntity i = this.getTypeInstance();
         i.setCurrency(Currency.getInstance("EUR"));
 

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualEntryBuilderImpl.java
@@ -21,8 +21,6 @@ package com.premiumminds.billy.spain.services.builders.impl;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -65,7 +63,7 @@ public class ESManualEntryBuilderImpl<TBuilder extends ESManualEntryBuilderImpl<
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
 
         for (Tax t : e.getProduct().getTaxes()) {

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualInvoiceEntryBuilderImpl.java
@@ -20,8 +20,6 @@ package com.premiumminds.billy.spain.services.builders.impl;
 
 import java.util.Date;
 
-import javax.validation.ValidationException;
-
 import org.apache.commons.lang3.time.DateUtils;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -60,7 +58,7 @@ public class ESManualInvoiceEntryBuilderImpl<TBuilder extends ESManualInvoiceEnt
     }
 
     @Override
-    protected void validateValues() throws BillyValidationException {
+    protected void validateValues() {
         GenericInvoiceEntryEntity e = this.getTypeInstance();
         for (Tax t : e.getProduct().getTaxes()) {
             if (this.daoContext.isSameOrSubContext(this.context, t.getContext())) {
@@ -71,7 +69,7 @@ public class ESManualInvoiceEntryBuilderImpl<TBuilder extends ESManualInvoiceEnt
             }
         }
         if (e.getTaxes().isEmpty()) {
-            throw new ValidationException(
+            throw new BillyValidationException(
                     GenericInvoiceEntryBuilderImpl.LOCALIZER.getString("exception.invalid_taxes"));
         }
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESPaymentBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESPaymentBuilderImpl.java
@@ -22,7 +22,6 @@ import java.math.BigDecimal;
 import java.util.Date;
 
 import javax.inject.Inject;
-import javax.validation.ValidationException;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
 import com.premiumminds.billy.core.services.builders.impl.PaymentBuilderImpl;
@@ -70,7 +69,7 @@ public class ESPaymentBuilderImpl<TBuilder extends ESPaymentBuilderImpl<TBuilder
     }
 
     @Override
-    protected void validateInstance() throws BillyValidationException, ValidationException {
+    protected void validateInstance() throws BillyValidationException {
         super.validateInstance();
         ESPaymentEntity p = this.getTypeInstance();
         BillyValidator.mandatory(p.getPaymentAmount(),

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESReceiptBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESReceiptBuilderImpl.java
@@ -18,8 +18,6 @@
  */
 package com.premiumminds.billy.spain.services.builders.impl;
 
-import javax.validation.ValidationException;
-
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice.CreditOrDebit;
 import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.spain.persistence.dao.AbstractDAOESGenericInvoice;
@@ -47,7 +45,7 @@ public class ESReceiptBuilderImpl<TBuilder extends ESReceiptBuilderImpl<TBuilder
     }
 
     @Override
-    protected void validateValues() throws ValidationException {
+    protected void validateValues() {
         ESReceiptEntity i = this.getTypeInstance();
         i.setCreditOrDebit(CreditOrDebit.CREDIT);
         super.validateValues();

--- a/pom.xml
+++ b/pom.xml
@@ -83,21 +83,6 @@
 				<scope>provided</scope>
 			</dependency>
 
-			<dependency>
-				<groupId>org.hibernate.validator</groupId>
-				<artifactId>hibernate-validator</artifactId>
-				<version>6.1.7.Final</version>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.el</groupId>
-				<artifactId>jakarta.el-api</artifactId>
-				<version>3.0.3</version>
-			</dependency>
-			<dependency>
-				<groupId>org.glassfish</groupId>
-				<artifactId>jakarta.el</artifactId>
-				<version>3.0.3</version>
-			</dependency>
 
 			<!-- GUICE -->
 			<dependency>


### PR DESCRIPTION
Corrects a lack of consistency with exceptions and validations. 
Removes javax.validation and relies only on BillyValidationException and Validate from commons-lang

- [ ] document API change in CHANGELOG