### PR TITLE
Removes saxon usage.

### DIFF
--- a/billy-gin/pom.xml
+++ b/billy-gin/pom.xml
@@ -74,11 +74,6 @@
 			<artifactId>fop</artifactId>
 			<version>1.0</version>
 		</dependency>
-		<dependency>
-			<groupId>net.sf.saxon</groupId>
-			<artifactId>saxon</artifactId>
-			<version>8.7</version>
-		</dependency>
 
 		<!-- QRCode -->
 		<dependency>

--- a/billy-gin/src/main/java/com/premiumminds/billy/gin/services/impl/pdf/FOPPDFTransformer.java
+++ b/billy-gin/src/main/java/com/premiumminds/billy/gin/services/impl/pdf/FOPPDFTransformer.java
@@ -47,9 +47,9 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
-import net.sf.saxon.TransformerFactoryImpl;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.fop.apps.FOPException;
 import org.apache.fop.apps.FOUserAgent;
@@ -65,14 +65,14 @@ public abstract class FOPPDFTransformer {
     private static final String QR_CODE_PATH = "qrCodePath";
     private static final String QR_CODE = "qrCode";
 
-    private final TransformerFactoryImpl transformerFactory;
+    private final TransformerFactory transformerFactory;
 
-    public FOPPDFTransformer(TransformerFactoryImpl transformerFactory) {
+    public FOPPDFTransformer(TransformerFactory transformerFactory) {
         this.transformerFactory = transformerFactory;
     }
 
     public FOPPDFTransformer() {
-        this(new TransformerFactoryImpl());
+        this(TransformerFactory.newInstance());
     }
 
     private Source mapParamsToSource(ParamsTree<String, String> documentParams) {


### PR DESCRIPTION
Replaced with javax.xml classes, which are implementation independent.

billy-gin already contains xalan, another JAXP implementation, trough fop.

Fixes #264