### PR TITLE
Compare BigDecimal with compateTo and not equals

### DIFF
--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/qrcode/QRCodeBuilder.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/qrcode/QRCodeBuilder.java
@@ -102,7 +102,7 @@ public class QRCodeBuilder {
 
         result.append(buildContextSpecificParameters(amountAndContextAndType, qrCodeData.getPtContexts()));
 
-        if(!exemptAmount.equals(BigDecimal.ZERO)) {
+        if(exemptAmount.compareTo(BigDecimal.ZERO) != 0) {
             result.append(FIELD_SEPARATOR)
                   .append(QRCodeConstants.NSOrNTAmount.getName()).append(DATA_SEPARATOR)
                   .append(validateBigDecimal(exemptAmount));

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -810,15 +810,15 @@ public class PTSAFTFileGenerator {
                 }
                 line.setTax(tax);
 
-                if ((tax.getTaxPercentage() != null && tax.getTaxPercentage().equals(BigDecimal.ZERO)) ||
-                        (tax.getTaxAmount() != null && tax.getTaxAmount().equals(BigDecimal.ZERO))) {
+                if ((tax.getTaxPercentage() != null && tax.getTaxPercentage().compareTo(BigDecimal.ZERO) == 0) ||
+                        (tax.getTaxAmount() != null && tax.getTaxAmount().compareTo(BigDecimal.ZERO) == 0)) {
                     line.setTaxExemptionReason(this.validateString("TaxExemptionReason", entry.getTaxExemptionReason(),
                             this.MAX_LENGTH_60, true));
                 }
             }
 
             /* NOT REQUIRED */
-            if (entry.getDiscountAmount() != null && !entry.getDiscountAmount().equals(BigDecimal.ZERO)) {
+            if (entry.getDiscountAmount() != null && entry.getDiscountAmount().compareTo(BigDecimal.ZERO) != 0) {
                 line.setSettlementAmount(entry.getDiscountAmount());
             }
 
@@ -972,7 +972,7 @@ public class PTSAFTFileGenerator {
             }
 
             if (settlement.getSettlementAmount() != null &&
-                    !settlement.getSettlementAmount().equals(this.validateBigDecimal(BigDecimal.ZERO))) {
+                    settlement.getSettlementAmount().compareTo(this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
                 return settlement;
             } else {
                 return null;
@@ -994,7 +994,7 @@ public class PTSAFTFileGenerator {
             throws RequiredFieldNotFoundException, DatatypeConfigurationException, InvalidPaymentMechanismException {
         DocumentTotals dt = null;
 
-        if (!this.validateBigDecimal(document.getAmountWithoutTax()).equals(this.validateBigDecimal(BigDecimal.ZERO))) {
+        if (this.validateBigDecimal(document.getAmountWithoutTax()).compareTo(this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
             dt = new DocumentTotals(); // 4.1.4.19
             /* REQUIRED */
             // 4.1.4.19.1

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -835,15 +835,15 @@ public class PTSAFTFileGenerator {
                 }
                 line.setTax(tax);
 
-                if ((tax.getTaxPercentage() != null && tax.getTaxPercentage().equals(BigDecimal.ZERO)) ||
-                        (tax.getTaxAmount() != null && tax.getTaxAmount().equals(BigDecimal.ZERO))) {
+                if ((tax.getTaxPercentage() != null && tax.getTaxPercentage().compareTo(BigDecimal.ZERO) == 0) ||
+                        (tax.getTaxAmount() != null && tax.getTaxAmount().compareTo(BigDecimal.ZERO) == 0)) {
                     line.setTaxExemptionReason(this.validateString("TaxExemptionReason", entry.getTaxExemptionReason(),
                             this.MAX_LENGTH_60, true));
                 }
             }
 
             /* NOT REQUIRED */
-            if (entry.getDiscountAmount() != null && !entry.getDiscountAmount().equals(BigDecimal.ZERO)) {
+            if (entry.getDiscountAmount() != null && entry.getDiscountAmount().compareTo(BigDecimal.ZERO) != 0) {
                 line.setSettlementAmount(entry.getDiscountAmount());
             }
 
@@ -997,7 +997,7 @@ public class PTSAFTFileGenerator {
             }
 
             if (settlement.getSettlementAmount() != null &&
-                    !settlement.getSettlementAmount().equals(this.validateBigDecimal(BigDecimal.ZERO))) {
+                    settlement.getSettlementAmount().compareTo(this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
                 return settlement;
             } else {
                 return null;
@@ -1019,7 +1019,7 @@ public class PTSAFTFileGenerator {
             throws RequiredFieldNotFoundException, DatatypeConfigurationException, InvalidPaymentMechanismException {
         DocumentTotals dt = null;
 
-        if (!this.validateBigDecimal(document.getAmountWithoutTax()).equals(this.validateBigDecimal(BigDecimal.ZERO))) {
+        if (this.validateBigDecimal(document.getAmountWithoutTax()).compareTo(this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
             dt = new DocumentTotals(); // 4.1.4.19
             /* REQUIRED */
             // 4.1.4.19.1

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -944,7 +944,7 @@ public class PTSAFTFileGenerator {
 
             /* NOT REQUIRED */
             if (entry.getDiscountAmount() != null
-                    && !entry.getDiscountAmount().equals(BigDecimal.ZERO)) {
+                    && entry.getDiscountAmount().compareTo(BigDecimal.ZERO) != 0) {
                 line.setSettlementAmount(entry.getDiscountAmount());
             }
 
@@ -1110,8 +1110,8 @@ public class PTSAFTFileGenerator {
             }
 
             if (settlement.getSettlementAmount() != null
-                    && !settlement.getSettlementAmount().equals(
-                            this.validateBigDecimal(BigDecimal.ZERO))) {
+                    && settlement.getSettlementAmount().compareTo(
+                            this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
                 return settlement;
             } else {
                 return null;
@@ -1133,8 +1133,8 @@ public class PTSAFTFileGenerator {
         DatatypeConfigurationException, InvalidPaymentMechanismException {
         DocumentTotals dt = null;
 
-        if (!this.validateBigDecimal(document.getAmountWithoutTax()).equals(
-                this.validateBigDecimal(BigDecimal.ZERO))) {
+        if (this.validateBigDecimal(document.getAmountWithoutTax()).compareTo(
+                this.validateBigDecimal(BigDecimal.ZERO)) != 0) {
             dt = new DocumentTotals(); // 4.1.4.19
             /* REQUIRED */
             // 4.1.4.19.1


### PR DESCRIPTION
from equals javadoc:
Compares this BigDecimal with the specified Object for equality. Unlike
compareTo, this method considers two BigDecimal objects equal only if they
are equal in value and scale (thus 2.0 is not equal to 2.00 when compared
by this method).

fixes #221 