### PR TITLE
Refactor KeyGenerator to use URL for private key

### DIFF
--- a/billy-france/src/main/java/com/premiumminds/billy/france/util/KeyGenerator.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/util/KeyGenerator.java
@@ -21,6 +21,7 @@ package com.premiumminds.billy.france.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URL;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -41,19 +42,19 @@ public class KeyGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(KeyGenerator.class);
 
-    private String privateKeyPath;
+    private final URL privateKey;
 
     /**
      * Generates the {@link PrivateKey} and {@link PublicKey} based on the
      * {@link PrivateKey} location.
      *
-     * @param privateKeyPath
+     * @param privateKey path to private key
      */
-    public KeyGenerator(String privateKeyPath) {
+    public KeyGenerator(URL privateKey) {
         if (Security.getProvider("BC") == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
-        this.privateKeyPath = privateKeyPath;
+        this.privateKey = privateKey;
     }
 
     private String getKeyFromFile() {
@@ -61,7 +62,7 @@ public class KeyGenerator {
         String key = "";
 
         try {
-            inputStream = this.getClass().getResourceAsStream(this.privateKeyPath);
+            inputStream = this.privateKey.openStream();
             key = IOUtils.toString(inputStream);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/KeyGenerator.java
@@ -21,6 +21,7 @@ package com.premiumminds.billy.portugal.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URL;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -41,19 +42,19 @@ public class KeyGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(KeyGenerator.class);
 
-    private String privateKeyPath;
+    private final URL privateKey;
 
     /**
      * Generates the {@link PrivateKey} and {@link PublicKey} based on the
      * {@link PrivateKey} location.
      *
-     * @param privateKeyPath path to private key
+     * @param privateKey path to private key
      */
-    public KeyGenerator(String privateKeyPath) {
+    public KeyGenerator(URL privateKey) {
         if (Security.getProvider("BC") == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
-        this.privateKeyPath = privateKeyPath;
+        this.privateKey = privateKey;
     }
 
     private String getKeyFromFile() {
@@ -61,7 +62,7 @@ public class KeyGenerator {
         String key = "";
 
         try {
-            inputStream = this.getClass().getResourceAsStream(this.privateKeyPath);
+            inputStream = this.privateKey.openStream();
             key = IOUtils.toString(inputStream);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/its/InvoiceIT.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/its/InvoiceIT.java
@@ -349,7 +349,7 @@ public class InvoiceIT {
     private PTIssuingParams getPtInvoiceIssuingParams() {
         PTIssuingParams invoiceParameters = PTIssuingParams.Util.newInstance();
 
-        KeyGenerator gen = new KeyGenerator(PRIVATE_KEY_DIR);
+        KeyGenerator gen = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
 
         invoiceParameters.setPrivateKey(gen.getPrivateKey());
         invoiceParameters.setPublicKey(gen.getPublicKey());
@@ -361,7 +361,7 @@ public class InvoiceIT {
     private PTIssuingParams getPtCreditNoteIssuingParams() {
         PTIssuingParams invoiceParameters = PTIssuingParams.Util.newInstance();
 
-        KeyGenerator gen = new KeyGenerator(PRIVATE_KEY_DIR);
+        KeyGenerator gen = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
 
         invoiceParameters.setPrivateKey(gen.getPrivateKey());
         invoiceParameters.setPublicKey(gen.getPublicKey());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
@@ -102,7 +102,7 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
 
     protected PTIssuingParams getParameters(String series, String EACCode, String privateKeyVersion) {
         PTIssuingParams parameters = new PTIssuingParamsImpl();
-        KeyGenerator generator = new KeyGenerator(PTPersistencyAbstractTest.PRIVATE_KEY_DIR);
+        KeyGenerator generator = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
         parameters.setPrivateKey(generator.getPrivateKey());
         parameters.setPublicKey(generator.getPublicKey());
         parameters.setPrivateKeyVersion(privateKeyVersion);

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/PTDocumentAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/PTDocumentAbstractTest.java
@@ -46,7 +46,7 @@ public class PTDocumentAbstractTest extends PTPersistencyAbstractTest {
 
     @BeforeEach
     public void setUpParamenters() {
-        KeyGenerator generator = new KeyGenerator(PTPersistencyAbstractTest.PRIVATE_KEY_DIR);
+        KeyGenerator generator = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
 
         this.parameters = new PTIssuingParamsImpl();
         this.parameters.setPrivateKey(generator.getPrivateKey());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/export/SAFTExportTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/export/SAFTExportTest.java
@@ -93,7 +93,7 @@ public class SAFTExportTest extends PTPersistencyAbstractTest {
         this.service.addHandler(PTCreditNoteEntity.class,
                 PTAbstractTest.injector.getInstance(PTCreditNoteIssuingHandler.class));
 
-        KeyGenerator generator = new KeyGenerator(PTPersistencyAbstractTest.PRIVATE_KEY_DIR);
+        KeyGenerator generator = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
 
         this.parameters = new PTIssuingParamsImpl();
         this.parameters.setPrivateKey(generator.getPrivateKey());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/persistence/PTPersistenceServiceAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/persistence/PTPersistenceServiceAbstractTest.java
@@ -33,7 +33,7 @@ public class PTPersistenceServiceAbstractTest extends PTPersistencyAbstractTest 
 
     @BeforeEach
     public void setUpParamenters() {
-        KeyGenerator generator = new KeyGenerator(PTPersistencyAbstractTest.PRIVATE_KEY_DIR);
+        KeyGenerator generator = new KeyGenerator(getClass().getResource(PRIVATE_KEY_DIR));
 
         this.parameters = new PTIssuingParamsImpl();
         this.parameters.setPrivateKey(generator.getPrivateKey());

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/util/KeyGenerator.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/util/KeyGenerator.java
@@ -21,6 +21,7 @@ package com.premiumminds.billy.spain.util;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.net.URL;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -41,19 +42,19 @@ public class KeyGenerator {
 
     private static final Logger log = LoggerFactory.getLogger(KeyGenerator.class);
 
-    private String privateKeyPath;
+    private final URL privateKey;
 
     /**
      * Generates the {@link PrivateKey} and {@link PublicKey} based on the
      * {@link PrivateKey} location.
      *
-     * @param privateKeyPath
+     * @param privateKey path to private key
      */
-    public KeyGenerator(String privateKeyPath) {
+    public KeyGenerator(URL privateKey) {
         if (Security.getProvider("BC") == null) {
             Security.addProvider(new BouncyCastleProvider());
         }
-        this.privateKeyPath = privateKeyPath;
+        this.privateKey = privateKey;
     }
 
     private String getKeyFromFile() {
@@ -61,7 +62,7 @@ public class KeyGenerator {
         String key = "";
 
         try {
-            inputStream = this.getClass().getResourceAsStream(this.privateKeyPath);
+            inputStream = this.privateKey.openStream();
             key = IOUtils.toString(inputStream);
         } catch (IOException e) {
             KeyGenerator.log.error(e.getMessage(), e);


### PR DESCRIPTION
URL is more friendly to external resources and compatible with java 9
modules.
Reading a resource in a another named module is not possible in Java 9.