### PR TITLE
Replace assert keyword with Junit assertions

### DIFF
--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestBankAccountBuilder.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestBankAccountBuilder.java
@@ -47,7 +47,7 @@ public class TestBankAccountBuilder extends AbstractTest {
 
         BankAccount bankAccount = builder.build();
 
-        assert (bankAccount != null);
+        Assertions.assertNotNull(bankAccount);
         Assertions.assertEquals(mockBankAccount.getIBANNumber(), bankAccount.getIBANNumber());
         Assertions.assertEquals(mockBankAccount.getBankIdentifier(), bankAccount.getBankIdentifier());
         Assertions.assertEquals(mockBankAccount.getBankAccountNumber(), bankAccount.getBankAccountNumber());

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestContactBuilder.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestContactBuilder.java
@@ -46,7 +46,7 @@ public class TestContactBuilder extends AbstractTest {
 
         Contact contact = builder.build();
 
-        assert (contact != null);
+        Assertions.assertNotNull(contact);
         Assertions.assertEquals(mockContact.getName(), contact.getName());
         Assertions.assertEquals(mockContact.getTelephone(), contact.getTelephone());
         Assertions.assertEquals(mockContact.getMobile(), contact.getMobile());

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestContextBuilder.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestContextBuilder.java
@@ -49,7 +49,7 @@ public class TestContextBuilder extends AbstractTest {
 
         Context context = builder.build();
 
-        assert (context != null);
+        Assertions.assertNotNull(context);
         Assertions.assertEquals(mockContext.getName(), context.getName());
         Assertions.assertEquals(mockContext.getDescription(), context.getDescription());
         Assertions.assertEquals(mockContext.getParentContext().getUID(), context.getParentContext().getUID());

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRAddressBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRAddressBuilder.java
@@ -49,7 +49,7 @@ public class TestFRAddressBuilder extends FRAbstractTest {
 
         FRAddress address = builder.build();
 
-        assert (address != null);
+        Assertions.assertNotNull(address);
         Assertions.assertEquals(mockAddress.getCity(), address.getCity());
         Assertions.assertEquals(mockAddress.getDetails(), address.getDetails());
         Assertions.assertEquals(mockAddress.getISOCountry(), address.getISOCountry());

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRApplicationBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRApplicationBuilder.java
@@ -61,15 +61,15 @@ public class TestFRApplicationBuilder extends FRAbstractTest {
 
         FRApplication application = builder.build();
 
-        assert (application != null);
+        Assertions.assertNotNull(application);
         Assertions.assertEquals(mockApplication.getName(), application.getName());
         Assertions.assertEquals(mockApplication.getVersion(), application.getVersion());
         Assertions.assertEquals(mockApplication.getDeveloperCompanyName(), application.getDeveloperCompanyName());
         Assertions.assertEquals(mockApplication.getDeveloperCompanyTaxIdentifier(),
                 application.getDeveloperCompanyTaxIdentifier());
         Assertions.assertEquals(mockApplication.getWebsiteAddress(), application.getWebsiteAddress());
-        assert (application.getContacts() != null);
-        assert (application.getMainContact() != null);
+        Assertions.assertNotNull(application.getContacts());
+        Assertions.assertNotNull(application.getMainContact());
 
     }
 }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRContactBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRContactBuilder.java
@@ -47,7 +47,7 @@ public class TestFRContactBuilder extends FRAbstractTest {
 
         FRContact contact = builder.build();
 
-        assert (contact != null);
+        Assertions.assertNotNull(contact);
         Assertions.assertEquals(mockContact.getEmail(), contact.getEmail());
         Assertions.assertEquals(mockContact.getFax(), contact.getFax());
         Assertions.assertEquals(mockContact.getMobile(), contact.getMobile());

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRTaxBuilder.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/builders/TestFRTaxBuilder.java
@@ -57,7 +57,7 @@ public class TestFRTaxBuilder extends FRAbstractTest {
 
         FRTax tax = builder.build();
 
-        assert (tax != null);
+        Assertions.assertNotNull(tax);
         Assertions.assertEquals(mockTax.getCode(), tax.getCode());
         Assertions.assertEquals(mockTax.getContext(), tax.getContext());
         Assertions.assertEquals(mockTax.getCurrency(), tax.getCurrency());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTAddressBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTAddressBuilder.java
@@ -49,7 +49,7 @@ public class TestPTAddressBuilder extends PTAbstractTest {
 
         PTAddress address = builder.build();
 
-        assert (address != null);
+        Assertions.assertNotNull(address);
         Assertions.assertEquals(mockAddress.getCity(), address.getCity());
         Assertions.assertEquals(mockAddress.getDetails(), address.getDetails());
         Assertions.assertEquals(mockAddress.getISOCountry(), address.getISOCountry());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTApplicationBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTApplicationBuilder.java
@@ -63,7 +63,7 @@ public class TestPTApplicationBuilder extends PTAbstractTest {
 
         PTApplication application = builder.build();
 
-        assert (application != null);
+        Assertions.assertNotNull(application);
         Assertions.assertEquals(mockApplication.getName(), application.getName());
         Assertions.assertEquals(mockApplication.getVersion(), application.getVersion());
         Assertions.assertEquals(mockApplication.getDeveloperCompanyName(), application.getDeveloperCompanyName());
@@ -73,8 +73,8 @@ public class TestPTApplicationBuilder extends PTAbstractTest {
         Assertions.assertEquals(mockApplication.getSoftwareCertificationNumber(),
                 application.getSoftwareCertificationNumber());
         Assertions.assertEquals(mockApplication.getApplicationKeysPath(), application.getApplicationKeysPath());
-        assert (application.getContacts() != null);
-        assert (application.getMainContact() != null);
+        Assertions.assertNotNull(application.getContacts());
+        Assertions.assertNotNull(application.getMainContact());
 
     }
 }

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTContactBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTContactBuilder.java
@@ -47,7 +47,7 @@ public class TestPTContactBuilder extends PTAbstractTest {
 
         PTContact contact = builder.build();
 
-        assert (contact != null);
+        Assertions.assertNotNull(contact);
         Assertions.assertEquals(mockContact.getEmail(), contact.getEmail());
         Assertions.assertEquals(mockContact.getFax(), contact.getFax());
         Assertions.assertEquals(mockContact.getMobile(), contact.getMobile());

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTTaxBuilder.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/builders/TestPTTaxBuilder.java
@@ -57,7 +57,7 @@ public class TestPTTaxBuilder extends PTAbstractTest {
 
         PTTax tax = builder.build();
 
-        assert (tax != null);
+        Assertions.assertNotNull(tax);
         Assertions.assertEquals(mockTax.getCode(), tax.getCode());
         Assertions.assertEquals(mockTax.getContext(), tax.getContext());
         Assertions.assertEquals(mockTax.getCurrency(), tax.getCurrency());

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESAddressBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESAddressBuilder.java
@@ -49,7 +49,7 @@ public class TestESAddressBuilder extends ESAbstractTest {
 
         ESAddress address = builder.build();
 
-        assert (address != null);
+        Assertions.assertNotNull(address);
         Assertions.assertEquals(mockAddress.getCity(), address.getCity());
         Assertions.assertEquals(mockAddress.getDetails(), address.getDetails());
         Assertions.assertEquals(mockAddress.getISOCountry(), address.getISOCountry());

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESApplicationBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESApplicationBuilder.java
@@ -61,15 +61,15 @@ public class TestESApplicationBuilder extends ESAbstractTest {
 
         ESApplication application = builder.build();
 
-        assert (application != null);
+        Assertions.assertNotNull(application);
         Assertions.assertEquals(mockApplication.getName(), application.getName());
         Assertions.assertEquals(mockApplication.getVersion(), application.getVersion());
         Assertions.assertEquals(mockApplication.getDeveloperCompanyName(), application.getDeveloperCompanyName());
         Assertions.assertEquals(mockApplication.getDeveloperCompanyTaxIdentifier(),
                 application.getDeveloperCompanyTaxIdentifier());
         Assertions.assertEquals(mockApplication.getWebsiteAddress(), application.getWebsiteAddress());
-        assert (application.getContacts() != null);
-        assert (application.getMainContact() != null);
+        Assertions.assertNotNull(application.getContacts());
+        Assertions.assertNotNull(application.getMainContact());
 
     }
 }

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESContactBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESContactBuilder.java
@@ -47,7 +47,7 @@ public class TestESContactBuilder extends ESAbstractTest {
 
         ESContact contact = builder.build();
 
-        assert (contact != null);
+        Assertions.assertNotNull(contact);
         Assertions.assertEquals(mockContact.getEmail(), contact.getEmail());
         Assertions.assertEquals(mockContact.getFax(), contact.getFax());
         Assertions.assertEquals(mockContact.getMobile(), contact.getMobile());

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESTaxBuilder.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/builders/TestESTaxBuilder.java
@@ -57,7 +57,7 @@ public class TestESTaxBuilder extends ESAbstractTest {
 
         ESTax tax = builder.build();
 
-        assert (tax != null);
+        Assertions.assertNotNull(tax);
         Assertions.assertEquals(mockTax.getCode(), tax.getCode());
         Assertions.assertEquals(mockTax.getContext(), tax.getContext());
         Assertions.assertEquals(mockTax.getCurrency(), tax.getCurrency());


### PR DESCRIPTION
assert keyword can be disabled and lead to bad tests.