### PR TITLE
Fixes non working getTaxes method in DAO taxes implementations

### DIFF
--- a/billy-france/src/main/java/com/premiumminds/billy/france/FranceBootstrap.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/FranceBootstrap.java
@@ -197,7 +197,7 @@ public class FranceBootstrap {
                     // Taxes
                     ZoneId paris = ZoneId.of("Europe/Paris");
                     Date from = Date.from(LocalDate.of(2017,1,1).atStartOfDay().atZone(paris).toInstant());
-                    Date to = Date.from(LocalDate.of(2018,1,1).atStartOfDay().atZone(paris).toInstant());
+                    Date to = Date.from(LocalDate.of(2114,1,1).atStartOfDay().atZone(paris).toInstant());
                     final FRTaxEntity VAT_NORMAL_CONTINENTAL_FRANCE = this.buildTaxEntity(daoFRTax, taxBuilder,
                             FRVATCode.NORMAL, CONTEXT_CONTINENTAL_FRANCE, Currency.getInstance("EUR"),
                             "IVA General Continente", "IVA", Tax.TaxRateType.PERCENTAGE, from, to,

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRTax.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRTax.java
@@ -31,5 +31,8 @@ public interface DAOFRTax extends DAOTax {
     @Override
     public FRTaxEntity getEntityInstance();
 
+    @Deprecated
     public List<JPAFRTaxEntity> getTaxes(FRRegionContextEntity context, Date validFrom, Date validTo);
+
+    public List<JPAFRTaxEntity> getTaxes(FRRegionContextEntity context, String code, Date validFrom, Date validTo);
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRTaxImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRTaxImpl.java
@@ -60,16 +60,15 @@ public class DAOFRTaxImpl extends DAOTaxImpl implements DAOFRTax {
 
         query.from(tax);
         List<BooleanExpression> predicates = new ArrayList<>();
-        BooleanExpression validFromPredicate = tax.validFrom.eq(validFrom);
-        predicates.add(validFromPredicate);
-        BooleanExpression validToPredicate = tax.validTo.eq(validTo);
-        predicates.add(validToPredicate);
-        BooleanExpression lessOrEqual = tax.validTo.loe(validFrom);
-        predicates.add(lessOrEqual);
-        BooleanExpression active = tax.active.eq(true);
-        predicates.add(active);
-        BooleanExpression contextPredicate = tax.context.eq(context);
-        predicates.add(contextPredicate);
+
+        predicates.add(tax.context.eq(context));
+        predicates.add(tax.active.eq(true));
+        if (validFrom != null) {
+            predicates.add(tax.validTo.after(validFrom).or(tax.validTo.isNull()));
+        }
+        if (validTo != null) {
+            predicates.add(tax.validFrom.before(validTo).or(tax.validFrom.isNull()));
+        }
 
         for (BooleanExpression e : predicates) {
             query.where(e);
@@ -77,7 +76,36 @@ public class DAOFRTaxImpl extends DAOTaxImpl implements DAOFRTax {
 
         List<JPAFRTaxEntity> list = query.select(tax).fetch();
         if (context.getParentContext() != null) {
-            list.addAll(this.getTaxes((FRRegionContextEntity) context.getParentContext(), validFrom, validTo));
+            list.addAll(this.getTaxes(context.getParentContext(), validFrom, validTo));
+        }
+        return list;
+    }
+
+    @Override
+    public List<JPAFRTaxEntity> getTaxes(FRRegionContextEntity context, String code, Date validFrom, Date validTo) {
+        QJPAFRTaxEntity tax = QJPAFRTaxEntity.jPAFRTaxEntity;
+        JPAQuery<JPAFRTaxEntity> query = new JPAQuery<>(this.getEntityManager());
+
+        query.from(tax);
+        List<BooleanExpression> predicates = new ArrayList<>();
+
+        predicates.add(tax.context.eq(context));
+        predicates.add(tax.active.eq(true));
+        predicates.add(tax.code.eq(code));
+        if (validFrom != null) {
+            predicates.add(tax.validTo.after(validFrom).or(tax.validTo.isNull()));
+        }
+        if (validTo != null) {
+            predicates.add(tax.validFrom.before(validTo).or(tax.validFrom.isNull()));
+        }
+
+        for (BooleanExpression e : predicates) {
+            query.where(e);
+        }
+
+        List<JPAFRTaxEntity> list = query.select(tax).fetch();
+        if (context.getParentContext() != null) {
+            list.addAll(this.getTaxes(context.getParentContext(), code, validFrom, validTo));
         }
         return list;
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRTaxBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRTaxBuilderImpl.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.france.services.builders.impl;
 
+import java.util.List;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -26,8 +27,8 @@ import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.core.util.Localizer;
 import com.premiumminds.billy.france.persistence.dao.DAOFRRegionContext;
 import com.premiumminds.billy.france.persistence.dao.DAOFRTax;
-import com.premiumminds.billy.france.persistence.entities.FRRegionContextEntity;
 import com.premiumminds.billy.france.persistence.entities.FRTaxEntity;
+import com.premiumminds.billy.france.persistence.entities.jpa.JPAFRTaxEntity;
 import com.premiumminds.billy.france.services.builders.FRTaxBuilder;
 import com.premiumminds.billy.france.services.entities.FRTax;
 
@@ -55,11 +56,10 @@ public class FRTaxBuilderImpl<TBuilder extends FRTaxBuilderImpl<TBuilder, TTax>,
         BillyValidator.mandatory(e.getCode(), FRTaxBuilderImpl.LOCALIZER.getString("field.tax_code"));
         BillyValidator.mandatory(e.getDescription(), FRTaxBuilderImpl.LOCALIZER.getString("field.tax_description"));
 
-        if (!((DAOFRTax) this.daoTax).getTaxes((FRRegionContextEntity) e.getContext(), e.getValidFrom(), e.getValidTo())
-                .isEmpty()) {
+        final List<JPAFRTaxEntity> taxes = ((DAOFRTax) this.daoTax).getTaxes(e.getContext(), e.getCode(), e.getValidFrom(), e.getValidTo());
+        if (!taxes.isEmpty()) {
             throw new BillyValidationException();
         }
         super.validateInstance();
     }
-
 }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRTax.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRTax.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy france (FR Pack).
+ *
+ * billy france (FR Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy france (FR Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy france (FR Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.france.test.services.dao;
+
+import java.util.Date;
+
+import com.premiumminds.billy.core.persistence.entities.TaxEntity;
+import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.france.BillyFrance;
+import com.premiumminds.billy.france.persistence.dao.DAOFRTax;
+import com.premiumminds.billy.france.persistence.entities.FRRegionContextEntity;
+import com.premiumminds.billy.france.services.entities.FRTax;
+import com.premiumminds.billy.france.test.FRPersistencyAbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestDAOFRTax extends FRPersistencyAbstractTest {
+
+    @Test
+    public void testGetTaxes() {
+
+        final BillyFrance billy = this.getInstance(BillyFrance.class);
+        final FRRegionContextEntity context = (FRRegionContextEntity)billy.contexts().continent().bretagne();
+
+        final DAOFRTax daoTax = this.getInstance(DAOFRTax.class);
+
+        final UID taxUID = billy.taxes().continent().normal().getUID();
+
+        final TaxEntity tax = assertDoesNotThrow(() -> daoTax.get(taxUID));
+        assertNotNull(tax);
+        assertTrue(daoTax.exists(taxUID));
+
+        assertAll(
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, new Date(1661973810L*1000L), new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, null, new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, new Date(1661973810L*1000L), null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, null, null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, new Date(0), new Date(Integer.MAX_VALUE * 1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, tax.getValidFrom(), tax.getValidTo()).size()),
+                () -> assertTrue(daoTax.getTaxes(context, FRTax.FRVATCode.NORMAL, new Date(1L),new Date(0L)).isEmpty())
+        );
+
+    }
+}

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/persistence/TestFRTaxPersistenceService.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/persistence/TestFRTaxPersistenceService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy france (FR Pack).
+ *
+ * billy france (FR Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy france (FR Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy france (FR Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.france.test.services.persistence;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.Currency;
+
+import com.premiumminds.billy.core.exceptions.BillyRuntimeException;
+import com.premiumminds.billy.core.services.entities.Tax;
+import com.premiumminds.billy.france.services.entities.FRRegionContext;
+import com.premiumminds.billy.france.services.entities.FRTax;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestFRTaxPersistenceService extends FRPersistenceServiceAbstractTest {
+
+    @Test
+    public void testDuplicateFails() {
+
+        final FRRegionContext bretagne = billy.contexts().continent().bretagne();
+
+        FRTax.Builder builder1 = createBuilder(bretagne);
+        FRTax.Builder builder2 = createBuilder(bretagne);
+
+        final FRTax tax = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax);
+
+        Assertions.assertThrows(BillyRuntimeException.class, () -> this.billy.taxes().persistence().create(builder2));
+
+    }
+
+    @Test
+    public void testSameCodeDifferentDatesSuccess() {
+
+        final FRRegionContext bretagne = billy.contexts().continent().bretagne();
+
+        FRTax.Builder builder1 = createBuilder(bretagne)
+                .setValidFrom(new java.util.Date(0))
+                .setValidTo(new java.util.Date(100L));
+
+        FRTax.Builder builder2 = createBuilder(bretagne)
+                .setValidFrom(new java.util.Date(100L))
+                .setValidTo(new java.util.Date(200L));
+
+        final FRTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final FRTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    @Test
+    public void testSameDatesDiferentCodesSuccess() {
+
+        final FRRegionContext bretagne = billy.contexts().continent().bretagne();
+
+        FRTax.Builder builder1 = createBuilder(bretagne)
+                .setCode("code1");
+
+        FRTax.Builder builder2 = createBuilder(bretagne)
+                .setCode("code2");
+
+        final FRTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final FRTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    private FRTax.Builder createBuilder(FRRegionContext madrid) {
+        return this.getInstance(FRTax.Builder.class)
+                .setContextUID(madrid.getUID())
+                .setTaxRate(Tax.TaxRateType.PERCENTAGE, new BigDecimal("3.14"))
+                .setCode("code1")
+                .setDescription("description 1")
+                .setValidFrom(new Date(0))
+                .setValidTo(new Date(1000L))
+                .setCurrency(Currency.getInstance("EUR"));
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/DAOPTTax.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/DAOPTTax.java
@@ -31,7 +31,10 @@ public interface DAOPTTax extends DAOTax {
     @Override
     public PTTaxEntity getEntityInstance();
 
+    @Deprecated
     public List<JPAPTTaxEntity> getTaxes(PTRegionContextEntity context, Date validFrom, Date validTo);
+
+    public List<JPAPTTaxEntity> getTaxes(PTRegionContextEntity context, String code, Date validFrom, Date validTo);
 
     public List<JPAPTTaxEntity> getTaxesForSAFTPT(PTRegionContextEntity context, Date validFrom, Date validTo);
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTTaxBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTTaxBuilderImpl.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.portugal.services.builders.impl;
 
+import java.util.List;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -26,8 +27,8 @@ import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.core.util.Localizer;
 import com.premiumminds.billy.portugal.persistence.dao.DAOPTRegionContext;
 import com.premiumminds.billy.portugal.persistence.dao.DAOPTTax;
-import com.premiumminds.billy.portugal.persistence.entities.PTRegionContextEntity;
 import com.premiumminds.billy.portugal.persistence.entities.PTTaxEntity;
+import com.premiumminds.billy.portugal.persistence.entities.jpa.JPAPTTaxEntity;
 import com.premiumminds.billy.portugal.services.builders.PTTaxBuilder;
 import com.premiumminds.billy.portugal.services.entities.PTTax;
 
@@ -55,8 +56,8 @@ public class PTTaxBuilderImpl<TBuilder extends PTTaxBuilderImpl<TBuilder, TTax>,
         BillyValidator.mandatory(e.getCode(), PTTaxBuilderImpl.LOCALIZER.getString("field.tax_code"));
         BillyValidator.mandatory(e.getDescription(), PTTaxBuilderImpl.LOCALIZER.getString("field.tax_description"));
 
-        if (!((DAOPTTax) this.daoTax).getTaxes((PTRegionContextEntity) e.getContext(), e.getValidFrom(), e.getValidTo())
-                .isEmpty()) {
+        final List<JPAPTTaxEntity> taxes = ((DAOPTTax) this.daoTax).getTaxes(e.getContext(), e.getCode(), e.getValidFrom(), e.getValidTo());
+        if (!taxes.isEmpty()) {
             throw new BillyValidationException();
         }
         super.validateInstance();

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTTax.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTTax.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.test.services.dao;
+
+import java.util.Date;
+
+import com.premiumminds.billy.core.persistence.entities.TaxEntity;
+import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.portugal.BillyPortugal;
+import com.premiumminds.billy.portugal.persistence.dao.DAOPTTax;
+import com.premiumminds.billy.portugal.persistence.entities.PTRegionContextEntity;
+import com.premiumminds.billy.portugal.services.entities.PTTax;
+import com.premiumminds.billy.portugal.test.PTPersistencyAbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestDAOPTTax extends PTPersistencyAbstractTest {
+
+    @Test
+    public void testGetTaxes() {
+
+        final BillyPortugal billy = this.getInstance(BillyPortugal.class);
+        final PTRegionContextEntity context = (PTRegionContextEntity)billy.contexts().continent().leiria();
+
+        final DAOPTTax daoTax = this.getInstance(DAOPTTax.class);
+
+        final UID taxUID = billy.taxes().continent().normal().getUID();
+
+        final TaxEntity tax = assertDoesNotThrow(() -> daoTax.get(taxUID));
+        assertNotNull(tax);
+        assertTrue(daoTax.exists(taxUID));
+
+        assertAll(
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, new Date(1661973810L*1000L), new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL,null, new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, new Date(1661973810L*1000L), null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, null, null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, new Date(0), new Date(Integer.MAX_VALUE * 1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, tax.getValidFrom(), tax.getValidTo()).size()),
+                () -> assertTrue(daoTax.getTaxes(context, PTTax.PTVATCode.NORMAL, new Date(1L),new Date(0L)).isEmpty())
+        );
+
+    }
+}

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/persistence/TestPTTaxPersistenceService.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/persistence/TestPTTaxPersistenceService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.test.services.persistence;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.Currency;
+
+import com.premiumminds.billy.core.exceptions.BillyRuntimeException;
+import com.premiumminds.billy.core.services.entities.Tax;
+import com.premiumminds.billy.portugal.services.entities.PTRegionContext;
+import com.premiumminds.billy.portugal.services.entities.PTTax;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestPTTaxPersistenceService extends PTPersistenceServiceAbstractTest {
+
+    @Test
+    public void testDuplicateFails() {
+
+        final PTRegionContext leiria = billy.contexts().continent().leiria();
+
+        PTTax.Builder builder1 = createBuilder(leiria);
+        PTTax.Builder builder2 = createBuilder(leiria);
+
+        final PTTax tax = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax);
+
+        Assertions.assertThrows(BillyRuntimeException.class, () -> this.billy.taxes().persistence().create(builder2));
+
+    }
+
+    @Test
+    public void testSameCodeDifferentDatesSuccess() {
+
+        final PTRegionContext leiria = billy.contexts().continent().leiria();
+
+        PTTax.Builder builder1 = createBuilder(leiria)
+                .setValidFrom(new java.util.Date(0))
+                .setValidTo(new java.util.Date(100L));
+
+        PTTax.Builder builder2 = createBuilder(leiria)
+                .setValidFrom(new java.util.Date(100L))
+                .setValidTo(new java.util.Date(200L));
+
+        final PTTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final PTTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    @Test
+    public void testSameDatesDiferentCodesSuccess() {
+
+        final PTRegionContext leiria = billy.contexts().continent().leiria();
+
+        PTTax.Builder builder1 = createBuilder(leiria)
+                .setCode("code1");
+
+        PTTax.Builder builder2 = createBuilder(leiria)
+                .setCode("code2");
+
+        final PTTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final PTTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    private PTTax.Builder createBuilder(PTRegionContext madrid) {
+        return this.getInstance(PTTax.Builder.class)
+                .setContextUID(madrid.getUID())
+                .setTaxRate(Tax.TaxRateType.PERCENTAGE, new BigDecimal("3.14"))
+                .setCode("code1")
+                .setDescription("description 1")
+                .setValidFrom(new Date(0))
+                .setValidTo(new Date(1000L))
+                .setCurrency(Currency.getInstance("EUR"));
+    }
+}

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESTax.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESTax.java
@@ -31,5 +31,8 @@ public interface DAOESTax extends DAOTax {
     @Override
     public ESTaxEntity getEntityInstance();
 
+    @Deprecated
     public List<JPAESTaxEntity> getTaxes(ESRegionContextEntity context, Date validFrom, Date validTo);
+
+    public List<JPAESTaxEntity> getTaxes(ESRegionContextEntity context, String code, Date validFrom, Date validTo);
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESTaxImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESTaxImpl.java
@@ -60,16 +60,15 @@ public class DAOESTaxImpl extends DAOTaxImpl implements DAOESTax {
 
         query.from(tax);
         List<BooleanExpression> predicates = new ArrayList<>();
-        BooleanExpression validFromPredicate = tax.validFrom.eq(validFrom);
-        predicates.add(validFromPredicate);
-        BooleanExpression validToPredicate = tax.validTo.eq(validTo);
-        predicates.add(validToPredicate);
-        BooleanExpression lessOrEqual = tax.validTo.loe(validFrom);
-        predicates.add(lessOrEqual);
-        BooleanExpression active = tax.active.eq(true);
-        predicates.add(active);
-        BooleanExpression contextPredicate = tax.context.eq(context);
-        predicates.add(contextPredicate);
+
+        predicates.add(tax.context.eq(context));
+        predicates.add(tax.active.eq(true));
+        if (validFrom != null) {
+            predicates.add(tax.validTo.after(validFrom).or(tax.validTo.isNull()));
+        }
+        if (validTo != null) {
+            predicates.add(tax.validFrom.before(validTo).or(tax.validFrom.isNull()));
+        }
 
         for (BooleanExpression e : predicates) {
             query.where(e);
@@ -77,7 +76,36 @@ public class DAOESTaxImpl extends DAOTaxImpl implements DAOESTax {
 
         List<JPAESTaxEntity> list = query.select(tax).fetch();
         if (context.getParentContext() != null) {
-            list.addAll(this.getTaxes((ESRegionContextEntity) context.getParentContext(), validFrom, validTo));
+            list.addAll(this.getTaxes(context.getParentContext(), validFrom, validTo));
+        }
+        return list;
+    }
+
+    @Override
+    public List<JPAESTaxEntity> getTaxes(ESRegionContextEntity context, String code, Date validFrom, Date validTo) {
+        QJPAESTaxEntity tax = QJPAESTaxEntity.jPAESTaxEntity;
+        JPAQuery<JPAESTaxEntity> query = new JPAQuery<>(this.getEntityManager());
+
+        query.from(tax);
+        List<BooleanExpression> predicates = new ArrayList<>();
+
+        predicates.add(tax.context.eq(context));
+        predicates.add(tax.active.eq(true));
+        predicates.add(tax.code.eq(code));
+        if (validFrom != null) {
+            predicates.add(tax.validTo.after(validFrom).or(tax.validTo.isNull()));
+        }
+        if (validTo != null) {
+            predicates.add(tax.validFrom.before(validTo).or(tax.validFrom.isNull()));
+        }
+
+        for (BooleanExpression e : predicates) {
+            query.where(e);
+        }
+
+        List<JPAESTaxEntity> list = query.select(tax).fetch();
+        if (context.getParentContext() != null) {
+            list.addAll(this.getTaxes(context.getParentContext(), code, validFrom, validTo));
         }
         return list;
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESTaxBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESTaxBuilderImpl.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.spain.services.builders.impl;
 
+import java.util.List;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.exceptions.BillyValidationException;
@@ -26,8 +27,8 @@ import com.premiumminds.billy.core.util.BillyValidator;
 import com.premiumminds.billy.core.util.Localizer;
 import com.premiumminds.billy.spain.persistence.dao.DAOESRegionContext;
 import com.premiumminds.billy.spain.persistence.dao.DAOESTax;
-import com.premiumminds.billy.spain.persistence.entities.ESRegionContextEntity;
 import com.premiumminds.billy.spain.persistence.entities.ESTaxEntity;
+import com.premiumminds.billy.spain.persistence.entities.jpa.JPAESTaxEntity;
 import com.premiumminds.billy.spain.services.builders.ESTaxBuilder;
 import com.premiumminds.billy.spain.services.entities.ESTax;
 
@@ -55,11 +56,10 @@ public class ESTaxBuilderImpl<TBuilder extends ESTaxBuilderImpl<TBuilder, TTax>,
         BillyValidator.mandatory(e.getCode(), ESTaxBuilderImpl.LOCALIZER.getString("field.tax_code"));
         BillyValidator.mandatory(e.getDescription(), ESTaxBuilderImpl.LOCALIZER.getString("field.tax_description"));
 
-        if (!((DAOESTax) this.daoTax).getTaxes((ESRegionContextEntity) e.getContext(), e.getValidFrom(), e.getValidTo())
-                .isEmpty()) {
+        final List<JPAESTaxEntity> taxes = ((DAOESTax) this.daoTax).getTaxes(e.getContext(), e.getCode(), e.getValidFrom(), e.getValidTo());
+        if (!taxes.isEmpty()) {
             throw new BillyValidationException();
         }
         super.validateInstance();
     }
-
 }

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESTax.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESTax.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy spain (ES Pack).
+ *
+ * billy spain (ES Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy spain (ES Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy spain (ES Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.spain.test.services.dao;
+
+import java.util.Date;
+
+import com.premiumminds.billy.core.persistence.entities.TaxEntity;
+import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.spain.BillySpain;
+import com.premiumminds.billy.spain.persistence.dao.DAOESTax;
+import com.premiumminds.billy.spain.persistence.entities.ESRegionContextEntity;
+import com.premiumminds.billy.spain.services.entities.ESTax;
+import com.premiumminds.billy.spain.test.ESPersistencyAbstractTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestDAOESTax extends ESPersistencyAbstractTest {
+
+    @Test
+    public void testGetTaxes() {
+
+        final BillySpain billy = this.getInstance(BillySpain.class);
+        final ESRegionContextEntity context = (ESRegionContextEntity)billy.contexts().continent().barcelona();
+
+        final DAOESTax daoTax = this.getInstance(DAOESTax.class);
+
+        final UID taxUID = billy.taxes().continent().normal().getUID();
+
+        final TaxEntity tax = assertDoesNotThrow(() -> daoTax.get(taxUID));
+        assertNotNull(tax);
+        assertTrue(daoTax.exists(taxUID));
+
+        assertAll(
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, new Date(1661973810L*1000L), new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, null, new Date(1661973810L*1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, new Date(1661973810L*1000L), null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, null, null).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, new Date(0), new Date(Integer.MAX_VALUE * 1000L)).size()),
+                () -> assertEquals(1, daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, tax.getValidFrom(), tax.getValidTo()).size()),
+                () -> assertTrue(daoTax.getTaxes(context, ESTax.ESVATCode.NORMAL, new Date(1L),new Date(0L)).isEmpty())
+        );
+
+    }
+}

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/persistence/TestESTaxPersistenceService.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/persistence/TestESTaxPersistenceService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy spain (ES Pack).
+ *
+ * billy spain (ES Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy spain (ES Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy spain (ES Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.spain.test.services.persistence;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.util.Currency;
+
+import com.premiumminds.billy.core.exceptions.BillyRuntimeException;
+import com.premiumminds.billy.core.services.entities.Tax;
+import com.premiumminds.billy.spain.services.entities.ESRegionContext;
+import com.premiumminds.billy.spain.services.entities.ESTax;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestESTaxPersistenceService extends ESPersistenceServiceAbstractTest {
+
+    @Test
+    public void testDuplicateFails() {
+
+        final ESRegionContext barcelona = billy.contexts().continent().barcelona();
+
+        ESTax.Builder builder1 = createBuilder(barcelona);
+        ESTax.Builder builder2 = createBuilder(barcelona);
+
+        final ESTax tax = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax);
+
+        Assertions.assertThrows(BillyRuntimeException.class, () -> this.billy.taxes().persistence().create(builder2));
+
+    }
+
+    @Test
+    public void testSameCodeDifferentDatesSuccess() {
+
+        final ESRegionContext barcelona = billy.contexts().continent().barcelona();
+
+        ESTax.Builder builder1 = createBuilder(barcelona)
+                .setValidFrom(new java.util.Date(0))
+                .setValidTo(new java.util.Date(100L));
+
+        ESTax.Builder builder2 = createBuilder(barcelona)
+                .setValidFrom(new java.util.Date(100L))
+                .setValidTo(new java.util.Date(200L));
+
+        final ESTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final ESTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    @Test
+    public void testSameDatesDiferentCodesSuccess() {
+
+        final ESRegionContext barcelona = billy.contexts().continent().barcelona();
+
+        ESTax.Builder builder1 = createBuilder(barcelona)
+                .setCode("code1");
+
+        ESTax.Builder builder2 = createBuilder(barcelona)
+                .setCode("code2");
+
+        final ESTax tax1 = this.billy.taxes().persistence().create(builder1);
+        Assertions.assertNotNull(tax1);
+
+        final ESTax tax2 = this.billy.taxes().persistence().create(builder2);
+        Assertions.assertNotNull(tax2);
+    }
+
+
+    private ESTax.Builder createBuilder(ESRegionContext madrid) {
+        return this.getInstance(ESTax.Builder.class)
+                .setContextUID(madrid.getUID())
+                .setTaxRate(Tax.TaxRateType.PERCENTAGE, new BigDecimal("3.14"))
+                .setCode("code1")
+                .setDescription("description 1")
+                .setValidFrom(new Date(0))
+                .setValidTo(new Date(1000L))
+                .setCurrency(Currency.getInstance("EUR"));
+    }
+}


### PR DESCRIPTION
getTaxes was always returning an empty list.

This problem was canceled out by another problem with tax builders
implementations ignoring valid duplicated taxes for the same context and
dates, but different codes/types/values, like normal, intermediate and
reduced taxes in Portugal.

This is a proper fix for #12 (previously fixed in #69, with some a minor change in #90)