### PR TITLE
Override saft final customer address country

### DIFF
--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -441,9 +441,18 @@ public class PTSAFTFileGenerator {
         this.context = "Customer.";
         Customer customer = new Customer();
         final String customerId;
+		final String addressDetailOverride;
+		final String addressCityOverride;
+		final String addressPostalCodeOverride;
+		final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(customerEntity.getUID())) {
             customerEntity.setTaxRegistrationNumber("999999990");
+
+			addressDetailOverride = "Desconhecido";
+			addressCityOverride = "Desconhecido";
+			addressPostalCodeOverride = "Desconhecido";
+			addressCountryOverride = "Desconhecido";
             customerId = "Consumidor final";
         } else {
             if ((this.optionalParam =
@@ -458,10 +467,23 @@ public class PTSAFTFileGenerator {
             }
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
+
+			addressDetailOverride = customerEntity.getBillingAddress().getDetails();
+			addressCityOverride = customerEntity.getBillingAddress().getCity();
+			addressPostalCodeOverride = customerEntity.getBillingAddress().getPostalCode();
+			addressCountryOverride = customerEntity.getBillingAddress().getISOCountry();
             customerId = customerEntity.getID().toString();
         }
-        this.updateCustomerGeneralInfo(customer, customerId, customerEntity.getTaxRegistrationNumber(),
-                customerEntity.getName(), (PTAddressEntity) customerEntity.getBillingAddress());
+        this.updateCustomerGeneralInfo(
+			customer,
+			customerId,
+			customerEntity.getTaxRegistrationNumber(),
+			customerEntity.getName(),
+			(PTAddressEntity) customerEntity.getBillingAddress(),
+			addressDetailOverride,
+			addressCityOverride,
+			addressPostalCodeOverride,
+			addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID, this.MAX_LENGTH_30, true));
         customer.setSelfBillingIndicator(
@@ -1071,15 +1093,30 @@ public class PTSAFTFileGenerator {
      * @param address
      * @throws RequiredFieldNotFoundException
      */
-    private void updateCustomerGeneralInfo(Customer customer, String customerID, String customerFinancialID,
-            String companyName, PTAddressEntity address) throws RequiredFieldNotFoundException {
+    private void updateCustomerGeneralInfo(
+		Customer customer,
+		String customerID,
+		String customerFinancialID,
+		String companyName,
+		PTAddressEntity address,
+		String addressDetailOverride,
+		String addressCityOverride,
+		String addressPostalCodeOverride,
+		String addressCountryOverride) throws RequiredFieldNotFoundException
+	{
         customer.setCustomerTaxID(this.validateString("CustomerTaxID", customerFinancialID, this.MAX_LENGTH_20, true));
 
         customer.setCompanyName(this.validateString("CompanyName", companyName, this.MAX_LENGTH_100, true));
 
         customer.setCustomerID(this.validateString("CustomerId", customerID, this.MAX_LENGTH_30, true));
 
-        customer.setBillingAddress(this.generateAddressStructure(address));
+		final AddressStructure customerAddress = this.generateAddressStructure(address);
+		customerAddress.setAddressDetail(addressDetailOverride);
+		customerAddress.setCity(addressCityOverride);
+		customerAddress.setPostalCode(addressPostalCodeOverride);
+		customerAddress.setCountry(addressCountryOverride);
+
+        customer.setBillingAddress(customerAddress);
     }
 
     /*************

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -438,55 +438,63 @@ public class PTSAFTFileGenerator {
             throws RequiredFieldNotFoundException, InvalidContactTypeException {
         this.context = "Customer.";
         Customer customer = new Customer();
-        final String customerId;
-        final String addressDetailOverride;
-        final String addressCityOverride;
-        final String addressPostalCodeOverride;
-        final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(customerEntity.getUID())) {
-            customerEntity.setTaxRegistrationNumber("999999990");
+            customer.setCustomerTaxID("999999990");
+            customer.setCompanyName("Consumidor final");
+            customer.setCustomerID("Consumidor final");
 
-            addressDetailOverride = "Desconhecido";
-            addressCityOverride = "Desconhecido";
-            addressPostalCodeOverride = "Desconhecido";
-            addressCountryOverride = "Desconhecido";
-            customerId = "Consumidor final";
+            final AddressStructure customerAddress = new AddressStructure();
+            customerAddress.setAddressDetail("Desconhecido");
+            customerAddress.setCity("Desconhecido");
+            customerAddress.setPostalCode("Desconhecido");
+            customerAddress.setCountry("Desconhecido");
+
+            customer.setBillingAddress(customerAddress);
         } else {
-            if ((this.optionalParam =
-                    this.validateString("Contact", customerEntity.getReferralName(), this.MAX_LENGTH_50, false))
-                            .length() > 0) {
+            this.optionalParam = this.validateString(
+                "Contact",
+                customerEntity.getReferralName(),
+                this.MAX_LENGTH_50,
+                false);
+            if (this.optionalParam.length() > 0) {
                 customer.setContact(this.optionalParam);
             }
 
             if (customerEntity.getShippingAddress() != null) {
-                customer.getShipToAddress()
-                        .add(this.generateAddressStructure((PTAddressEntity) customerEntity.getShippingAddress()));
+                customer
+                    .getShipToAddress()
+                    .add(this.generateAddressStructure((PTAddressEntity) customerEntity.getShippingAddress()));
             }
+
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-            final Address customerBillingAddress = customerEntity.getBillingAddress();
-            addressDetailOverride = customerBillingAddress.getDetails();
-            addressCityOverride = customerBillingAddress.getCity();
-            addressPostalCodeOverride = customerBillingAddress.getPostalCode();
-            addressCountryOverride = customerBillingAddress.getISOCountry();
-            customerId = customerEntity.getID().toString();
+            customer.setCustomerTaxID(this.validateString(
+                "CustomerTaxID",
+                customerEntity.getTaxRegistrationNumber(),
+                this.MAX_LENGTH_20,
+                true));
+
+            customer.setCompanyName(this.validateString(
+                "CompanyName",
+                customerEntity.getName(),
+                this.MAX_LENGTH_100, true));
+
+            customer.setCustomerID(this.validateString(
+                "CustomerId",
+                customerEntity.getID().toString(),
+                this.MAX_LENGTH_30, true));
+
+            customer.setBillingAddress(this.generateAddressStructure(customerEntity.getBillingAddress()));
         }
-        this.updateCustomerGeneralInfo(
-            customer,
-            customerId,
-            customerEntity.getTaxRegistrationNumber(),
-            customerEntity.getName(),
-            (PTAddressEntity) customerEntity.getBillingAddress(),
-            addressDetailOverride,
-            addressCityOverride,
-            addressPostalCodeOverride,
-            addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID, this.MAX_LENGTH_30, true));
-        customer.setSelfBillingIndicator(
-                this.validateInteger("SelfBillingIndicator", this.SELF_BILLING_INDICATOR, this.MAX_LENGTH_1, true));
+        customer.setSelfBillingIndicator(this.validateInteger(
+            "SelfBillingIndicator",
+            this.SELF_BILLING_INDICATOR,
+            this.MAX_LENGTH_1,
+            true));
 
         return customer;
     }
@@ -1075,47 +1083,6 @@ public class PTSAFTFileGenerator {
                 throw new InvalidInvoiceTypeException(document.getType().toString(), document.getSeries());
 
         }
-    }
-
-    /*************
-     * CUSTOMERS *
-     *************/
-    /**
-     * Sets the main information about the Customer
-     *
-     * @param customer
-     * @param customerID
-     * @param customerFinancialID
-     *        - NIF
-     * @param companyName
-     *        - the company where the customer works
-     * @param address
-     * @throws RequiredFieldNotFoundException
-     */
-    private void updateCustomerGeneralInfo(
-        Customer customer,
-        String customerID,
-        String customerFinancialID,
-        String companyName,
-        PTAddressEntity address,
-        String addressDetailOverride,
-        String addressCityOverride,
-        String addressPostalCodeOverride,
-        String addressCountryOverride) throws RequiredFieldNotFoundException
-    {
-        customer.setCustomerTaxID(this.validateString("CustomerTaxID", customerFinancialID, this.MAX_LENGTH_20, true));
-
-        customer.setCompanyName(this.validateString("CompanyName", companyName, this.MAX_LENGTH_100, true));
-
-        customer.setCustomerID(this.validateString("CustomerId", customerID, this.MAX_LENGTH_30, true));
-
-        final AddressStructure customerAddress = this.generateAddressStructure(address);
-        customerAddress.setAddressDetail(addressDetailOverride);
-        customerAddress.setCity(addressCityOverride);
-        customerAddress.setPostalCode(addressPostalCodeOverride);
-        customerAddress.setCountry(addressCountryOverride);
-
-        customer.setBillingAddress(customerAddress);
     }
 
     /*************

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -18,46 +18,15 @@
  */
 package com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01;
 
-import com.premiumminds.billy.core.services.entities.Address;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
-
-import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
 import com.google.common.io.ByteStreams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.premiumminds.billy.core.persistence.dao.TransactionWrapper;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.Product.ProductType;
 import com.premiumminds.billy.core.services.entities.Tax.TaxRateType;
+import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
 import com.premiumminds.billy.core.util.BillyMathContext;
 import com.premiumminds.billy.core.util.PaymentMechanism;
 import com.premiumminds.billy.portugal.Config;
@@ -124,6 +93,34 @@ import com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01.schema.Su
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01.schema.Tax;
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01.schema.TaxTable;
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01.schema.TaxTableEntry;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PTSAFTFileGenerator {
 

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -439,18 +439,18 @@ public class PTSAFTFileGenerator {
         this.context = "Customer.";
         Customer customer = new Customer();
         final String customerId;
-		final String addressDetailOverride;
-		final String addressCityOverride;
-		final String addressPostalCodeOverride;
-		final String addressCountryOverride;
+        final String addressDetailOverride;
+        final String addressCityOverride;
+        final String addressPostalCodeOverride;
+        final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(customerEntity.getUID())) {
             customerEntity.setTaxRegistrationNumber("999999990");
 
-			addressDetailOverride = "Desconhecido";
-			addressCityOverride = "Desconhecido";
-			addressPostalCodeOverride = "Desconhecido";
-			addressCountryOverride = "Desconhecido";
+            addressDetailOverride = "Desconhecido";
+            addressCityOverride = "Desconhecido";
+            addressPostalCodeOverride = "Desconhecido";
+            addressCountryOverride = "Desconhecido";
             customerId = "Consumidor final";
         } else {
             if ((this.optionalParam =
@@ -466,23 +466,23 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			final Address customerBillingAddress = customerEntity.getBillingAddress();
-			addressDetailOverride = customerBillingAddress.getDetails();
-			addressCityOverride = customerBillingAddress.getCity();
-			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
-			addressCountryOverride = customerBillingAddress.getISOCountry();
+            final Address customerBillingAddress = customerEntity.getBillingAddress();
+            addressDetailOverride = customerBillingAddress.getDetails();
+            addressCityOverride = customerBillingAddress.getCity();
+            addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+            addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(
-			customer,
-			customerId,
-			customerEntity.getTaxRegistrationNumber(),
-			customerEntity.getName(),
-			(PTAddressEntity) customerEntity.getBillingAddress(),
-			addressDetailOverride,
-			addressCityOverride,
-			addressPostalCodeOverride,
-			addressCountryOverride);
+            customer,
+            customerId,
+            customerEntity.getTaxRegistrationNumber(),
+            customerEntity.getName(),
+            (PTAddressEntity) customerEntity.getBillingAddress(),
+            addressDetailOverride,
+            addressCityOverride,
+            addressPostalCodeOverride,
+            addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID, this.MAX_LENGTH_30, true));
         customer.setSelfBillingIndicator(
@@ -1093,27 +1093,27 @@ public class PTSAFTFileGenerator {
      * @throws RequiredFieldNotFoundException
      */
     private void updateCustomerGeneralInfo(
-		Customer customer,
-		String customerID,
-		String customerFinancialID,
-		String companyName,
-		PTAddressEntity address,
-		String addressDetailOverride,
-		String addressCityOverride,
-		String addressPostalCodeOverride,
-		String addressCountryOverride) throws RequiredFieldNotFoundException
-	{
+        Customer customer,
+        String customerID,
+        String customerFinancialID,
+        String companyName,
+        PTAddressEntity address,
+        String addressDetailOverride,
+        String addressCityOverride,
+        String addressPostalCodeOverride,
+        String addressCountryOverride) throws RequiredFieldNotFoundException
+    {
         customer.setCustomerTaxID(this.validateString("CustomerTaxID", customerFinancialID, this.MAX_LENGTH_20, true));
 
         customer.setCompanyName(this.validateString("CompanyName", companyName, this.MAX_LENGTH_100, true));
 
         customer.setCustomerID(this.validateString("CustomerId", customerID, this.MAX_LENGTH_30, true));
 
-		final AddressStructure customerAddress = this.generateAddressStructure(address);
-		customerAddress.setAddressDetail(addressDetailOverride);
-		customerAddress.setCity(addressCityOverride);
-		customerAddress.setPostalCode(addressPostalCodeOverride);
-		customerAddress.setCountry(addressCountryOverride);
+        final AddressStructure customerAddress = this.generateAddressStructure(address);
+        customerAddress.setAddressDetail(addressDetailOverride);
+        customerAddress.setCity(addressCityOverride);
+        customerAddress.setPostalCode(addressPostalCodeOverride);
+        customerAddress.setCountry(addressCountryOverride);
 
         customer.setBillingAddress(customerAddress);
     }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.portugal.services.export.saftpt.v1_02_01;
 
+import com.premiumminds.billy.core.services.entities.Address;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -468,10 +469,11 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			addressDetailOverride = customerEntity.getBillingAddress().getDetails();
-			addressCityOverride = customerEntity.getBillingAddress().getCity();
-			addressPostalCodeOverride = customerEntity.getBillingAddress().getPostalCode();
-			addressCountryOverride = customerEntity.getBillingAddress().getISOCountry();
+			final Address customerBillingAddress = customerEntity.getBillingAddress();
+			addressDetailOverride = customerBillingAddress.getDetails();
+			addressCityOverride = customerBillingAddress.getCity();
+			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+			addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01;
 
+import com.premiumminds.billy.core.services.entities.Address;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -473,10 +474,11 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			addressDetailOverride = customerEntity.getBillingAddress().getDetails();
-			addressCityOverride = customerEntity.getBillingAddress().getCity();
-			addressPostalCodeOverride = customerEntity.getBillingAddress().getPostalCode();
-			addressCountryOverride = customerEntity.getBillingAddress().getISOCountry();
+			final Address customerBillingAddress = customerEntity.getBillingAddress();
+			addressDetailOverride = customerBillingAddress.getDetails();
+			addressCityOverride = customerBillingAddress.getCity();
+			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+			addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -444,17 +444,17 @@ public class PTSAFTFileGenerator {
         this.context = "Customer.";
         Customer customer = new Customer();
         final String customerId;
-		final String addressDetailOverride;
-		final String addressCityOverride;
-		final String addressPostalCodeOverride;
-		final String addressCountryOverride;
+        final String addressDetailOverride;
+        final String addressCityOverride;
+        final String addressPostalCodeOverride;
+        final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(customerEntity.getUID())) {
             customerEntity.setTaxRegistrationNumber("999999990");
-			addressDetailOverride = "Desconhecido";
-			addressCityOverride = "Desconhecido";
-			addressPostalCodeOverride = "Desconhecido";
-			addressCountryOverride = "Desconhecido";
+            addressDetailOverride = "Desconhecido";
+            addressCityOverride = "Desconhecido";
+            addressPostalCodeOverride = "Desconhecido";
+            addressCountryOverride = "Desconhecido";
             customerId = "Consumidor final";
         } else {
             if ((this.optionalParam =
@@ -470,23 +470,23 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			final Address customerBillingAddress = customerEntity.getBillingAddress();
-			addressDetailOverride = customerBillingAddress.getDetails();
-			addressCityOverride = customerBillingAddress.getCity();
-			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
-			addressCountryOverride = customerBillingAddress.getISOCountry();
+            final Address customerBillingAddress = customerEntity.getBillingAddress();
+            addressDetailOverride = customerBillingAddress.getDetails();
+            addressCityOverride = customerBillingAddress.getCity();
+            addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+            addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(
-			customer,
-			customerId,
-			customerEntity.getTaxRegistrationNumber(),
-			customerEntity.getName(),
-			(PTAddressEntity) customerEntity.getBillingAddress(),
-			addressDetailOverride,
-			addressCityOverride,
-			addressPostalCodeOverride,
-			addressCountryOverride);
+            customer,
+            customerId,
+            customerEntity.getTaxRegistrationNumber(),
+            customerEntity.getName(),
+            (PTAddressEntity) customerEntity.getBillingAddress(),
+            addressDetailOverride,
+            addressCityOverride,
+            addressPostalCodeOverride,
+            addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID, this.MAX_LENGTH_30, true));
         customer.setSelfBillingIndicator(
@@ -1117,27 +1117,27 @@ public class PTSAFTFileGenerator {
      * @throws RequiredFieldNotFoundException
      */
     private void updateCustomerGeneralInfo(
-		Customer customer,
-		String customerID,
-		String customerFinancialID,
-		String companyName,
-		PTAddressEntity address,
-		String addressDetailOverride,
-		String addressCityOverride,
-		String addressPostalCodeOverride,
-		String addressCountryOverride) throws RequiredFieldNotFoundException
-	{
+        Customer customer,
+        String customerID,
+        String customerFinancialID,
+        String companyName,
+        PTAddressEntity address,
+        String addressDetailOverride,
+        String addressCityOverride,
+        String addressPostalCodeOverride,
+        String addressCountryOverride) throws RequiredFieldNotFoundException
+    {
         customer.setCustomerTaxID(this.validateString("CustomerTaxID", customerFinancialID, this.MAX_LENGTH_20, true));
         customer.setCompanyName(this.validateString("CompanyName", companyName, this.MAX_LENGTH_100, true));
         customer.setCustomerID(this.validateString("CustomerId", customerID, this.MAX_LENGTH_30, true));
 
-		final AddressStructure customerAddress = this.generateAddressStructure(address);
-		customerAddress.setAddressDetail(addressDetailOverride);
-		customerAddress.setCity(addressCityOverride);
-		customerAddress.setPostalCode(addressPostalCodeOverride);
-		customerAddress.setCountry(addressCountryOverride);
+        final AddressStructure customerAddress = this.generateAddressStructure(address);
+        customerAddress.setAddressDetail(addressDetailOverride);
+        customerAddress.setCity(addressCityOverride);
+        customerAddress.setPostalCode(addressPostalCodeOverride);
+        customerAddress.setCountry(addressCountryOverride);
 
-		customer.setBillingAddress(customerAddress);
+        customer.setBillingAddress(customerAddress);
     }
 
     /*************

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -18,47 +18,15 @@
  */
 package com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01;
 
-import com.premiumminds.billy.core.services.entities.Address;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.math.MathContext;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import java.util.Optional;
-import javax.inject.Inject;
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Marshaller;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
-
-import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
 import com.google.common.io.ByteStreams;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.premiumminds.billy.core.persistence.dao.TransactionWrapper;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.Product.ProductType;
 import com.premiumminds.billy.core.services.entities.Tax.TaxRateType;
+import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
 import com.premiumminds.billy.core.util.BillyMathContext;
 import com.premiumminds.billy.core.util.PaymentMechanism;
 import com.premiumminds.billy.portugal.Config;
@@ -127,6 +95,34 @@ import com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01.schema.Su
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01.schema.Tax;
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01.schema.TaxTable;
 import com.premiumminds.billy.portugal.services.export.saftpt.v1_03_01.schema.TaxTableEntry;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.xml.XMLConstants;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Marshaller;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PTSAFTFileGenerator {
 

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -108,6 +108,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
@@ -468,11 +469,20 @@ public class PTSAFTFileGenerator {
         this.context = "Customer.";
         Customer customer = new Customer();
         final String customerId;
+		final String addressDetailOverride;
+		final String addressCityOverride;
+		final String addressPostalCodeOverride;
+		final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(
                 customerEntity.getUID())) {
             customerEntity.setTaxRegistrationNumber("999999990");
-            customerId = "Consumidor final";
+
+			addressDetailOverride = "Desconhecido";
+			addressCityOverride = "Desconhecido";
+			addressPostalCodeOverride = "Desconhecido";
+			addressCountryOverride = "Desconhecido";
+			customerId = "Consumidor final";
         } else {
             if ((this.optionalParam = this
                     .validateString("Contact",
@@ -489,11 +499,23 @@ public class PTSAFTFileGenerator {
             }
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
+
+			addressDetailOverride = customerEntity.getBillingAddress().getDetails();
+			addressCityOverride = customerEntity.getBillingAddress().getCity();
+			addressPostalCodeOverride = customerEntity.getBillingAddress().getPostalCode();
+			addressCountryOverride = customerEntity.getBillingAddress().getISOCountry();
             customerId = customerEntity.getID().toString();
         }
-        this.updateCustomerGeneralInfo(customer, customerId, customerEntity.getTaxRegistrationNumber(),
-                customerEntity.getName(), (PTAddressEntity) customerEntity
-                        .getBillingAddress());
+        this.updateCustomerGeneralInfo(
+			customer,
+			customerId,
+			customerEntity.getTaxRegistrationNumber(),
+			customerEntity.getName(),
+			(PTAddressEntity) customerEntity.getBillingAddress(),
+			addressDetailOverride,
+			addressCityOverride,
+			addressPostalCodeOverride,
+			addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID,
                 this.MAX_LENGTH_30, true));
@@ -1215,10 +1237,18 @@ public class PTSAFTFileGenerator {
      * @param address
      * @throws RequiredFieldNotFoundException
      */
-    private void updateCustomerGeneralInfo(Customer customer,
-            String customerID, String customerFinancialID, String companyName,
-            PTAddressEntity address) throws RequiredFieldNotFoundException {
-        customer.setCustomerTaxID(this.validateString("CustomerTaxID",
+    private void updateCustomerGeneralInfo(
+		Customer customer,
+		String customerID,
+		String customerFinancialID,
+		String companyName,
+		PTAddressEntity address,
+		String addressDetailOverride,
+		String addressCityOverride,
+		String addressPostalCodeOverride,
+		String addressCountryOverride) throws RequiredFieldNotFoundException
+	{
+		customer.setCustomerTaxID(this.validateString("CustomerTaxID",
                 customerFinancialID, this.MAX_LENGTH_20, true));
 
         customer.setCompanyName(this.validateString("CompanyName", companyName,
@@ -1227,7 +1257,13 @@ public class PTSAFTFileGenerator {
         customer.setCustomerID(this.validateString("CustomerId", customerID,
                 this.MAX_LENGTH_30, true));
 
-        customer.setBillingAddress(this.generateAddressStructure(address));
+		final AddressStructure customerAddress = this.generateAddressStructure(address);
+		customerAddress.setAddressDetail(addressDetailOverride);
+		customerAddress.setCity(addressCityOverride);
+		customerAddress.setPostalCode(addressPostalCodeOverride);
+		customerAddress.setCountry(addressCountryOverride);
+
+		customer.setBillingAddress(customerAddress);
     }
 
     /*************

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -109,7 +109,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -469,20 +469,20 @@ public class PTSAFTFileGenerator {
         this.context = "Customer.";
         Customer customer = new Customer();
         final String customerId;
-		final String addressDetailOverride;
-		final String addressCityOverride;
-		final String addressPostalCodeOverride;
-		final String addressCountryOverride;
+        final String addressDetailOverride;
+        final String addressCityOverride;
+        final String addressPostalCodeOverride;
+        final String addressCountryOverride;
 
         if (this.config.getUID(Key.Customer.Generic.UUID).equals(
                 customerEntity.getUID())) {
             customerEntity.setTaxRegistrationNumber("999999990");
 
-			addressDetailOverride = "Desconhecido";
-			addressCityOverride = "Desconhecido";
-			addressPostalCodeOverride = "Desconhecido";
-			addressCountryOverride = "Desconhecido";
-			customerId = "Consumidor final";
+            addressDetailOverride = "Desconhecido";
+            addressCityOverride = "Desconhecido";
+            addressPostalCodeOverride = "Desconhecido";
+            addressCountryOverride = "Desconhecido";
+            customerId = "Consumidor final";
         } else {
             if ((this.optionalParam = this
                     .validateString("Contact",
@@ -500,23 +500,23 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			final Address customerBillingAddress = customerEntity.getBillingAddress();
-			addressDetailOverride = customerBillingAddress.getDetails();
-			addressCityOverride = customerBillingAddress.getCity();
-			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
-			addressCountryOverride = customerBillingAddress.getISOCountry();
+            final Address customerBillingAddress = customerEntity.getBillingAddress();
+            addressDetailOverride = customerBillingAddress.getDetails();
+            addressCityOverride = customerBillingAddress.getCity();
+            addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+            addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(
-			customer,
-			customerId,
-			customerEntity.getTaxRegistrationNumber(),
-			customerEntity.getName(),
-			(PTAddressEntity) customerEntity.getBillingAddress(),
-			addressDetailOverride,
-			addressCityOverride,
-			addressPostalCodeOverride,
-			addressCountryOverride);
+            customer,
+            customerId,
+            customerEntity.getTaxRegistrationNumber(),
+            customerEntity.getName(),
+            (PTAddressEntity) customerEntity.getBillingAddress(),
+            addressDetailOverride,
+            addressCityOverride,
+            addressPostalCodeOverride,
+            addressCountryOverride);
 
         customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID,
                 this.MAX_LENGTH_30, true));
@@ -1239,17 +1239,17 @@ public class PTSAFTFileGenerator {
      * @throws RequiredFieldNotFoundException
      */
     private void updateCustomerGeneralInfo(
-		Customer customer,
-		String customerID,
-		String customerFinancialID,
-		String companyName,
-		PTAddressEntity address,
-		String addressDetailOverride,
-		String addressCityOverride,
-		String addressPostalCodeOverride,
-		String addressCountryOverride) throws RequiredFieldNotFoundException
-	{
-		customer.setCustomerTaxID(this.validateString("CustomerTaxID",
+        Customer customer,
+        String customerID,
+        String customerFinancialID,
+        String companyName,
+        PTAddressEntity address,
+        String addressDetailOverride,
+        String addressCityOverride,
+        String addressPostalCodeOverride,
+        String addressCountryOverride) throws RequiredFieldNotFoundException
+    {
+        customer.setCustomerTaxID(this.validateString("CustomerTaxID",
                 customerFinancialID, this.MAX_LENGTH_20, true));
 
         customer.setCompanyName(this.validateString("CompanyName", companyName,
@@ -1258,13 +1258,13 @@ public class PTSAFTFileGenerator {
         customer.setCustomerID(this.validateString("CustomerId", customerID,
                 this.MAX_LENGTH_30, true));
 
-		final AddressStructure customerAddress = this.generateAddressStructure(address);
-		customerAddress.setAddressDetail(addressDetailOverride);
-		customerAddress.setCity(addressCityOverride);
-		customerAddress.setPostalCode(addressPostalCodeOverride);
-		customerAddress.setCountry(addressCountryOverride);
+        final AddressStructure customerAddress = this.generateAddressStructure(address);
+        customerAddress.setAddressDetail(addressDetailOverride);
+        customerAddress.setCity(addressCityOverride);
+        customerAddress.setPostalCode(addressPostalCodeOverride);
+        customerAddress.setCountry(addressCountryOverride);
 
-		customer.setBillingAddress(customerAddress);
+        customer.setBillingAddress(customerAddress);
     }
 
     /*************

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -23,6 +23,7 @@ import com.premiumminds.billy.core.persistence.dao.TransactionWrapper;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.UID;
+import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.Product.ProductType;
 import com.premiumminds.billy.core.services.entities.Tax.TaxRateType;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
@@ -500,10 +501,11 @@ public class PTSAFTFileGenerator {
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-			addressDetailOverride = customerEntity.getBillingAddress().getDetails();
-			addressCityOverride = customerEntity.getBillingAddress().getCity();
-			addressPostalCodeOverride = customerEntity.getBillingAddress().getPostalCode();
-			addressCountryOverride = customerEntity.getBillingAddress().getISOCountry();
+			final Address customerBillingAddress = customerEntity.getBillingAddress();
+			addressDetailOverride = customerBillingAddress.getDetails();
+			addressCityOverride = customerBillingAddress.getCity();
+			addressPostalCodeOverride = customerBillingAddress.getPostalCode();
+			addressCountryOverride = customerBillingAddress.getISOCountry();
             customerId = customerEntity.getID().toString();
         }
         this.updateCustomerGeneralInfo(

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -468,61 +468,63 @@ public class PTSAFTFileGenerator {
         throws RequiredFieldNotFoundException, InvalidContactTypeException {
         this.context = "Customer.";
         Customer customer = new Customer();
-        final String customerId;
-        final String addressDetailOverride;
-        final String addressCityOverride;
-        final String addressPostalCodeOverride;
-        final String addressCountryOverride;
 
-        if (this.config.getUID(Key.Customer.Generic.UUID).equals(
-                customerEntity.getUID())) {
-            customerEntity.setTaxRegistrationNumber("999999990");
+        if (this.config.getUID(Key.Customer.Generic.UUID).equals(customerEntity.getUID())) {
+            customer.setCustomerTaxID("999999990");
+            customer.setCompanyName("Consumidor final");
+            customer.setCustomerID("Consumidor final");
 
-            addressDetailOverride = "Desconhecido";
-            addressCityOverride = "Desconhecido";
-            addressPostalCodeOverride = "Desconhecido";
-            addressCountryOverride = "Desconhecido";
-            customerId = "Consumidor final";
+            final AddressStructure customerAddress = new AddressStructure();
+            customerAddress.setAddressDetail("Desconhecido");
+            customerAddress.setCity("Desconhecido");
+            customerAddress.setPostalCode("Desconhecido");
+            customerAddress.setCountry("Desconhecido");
+
+            customer.setBillingAddress(customerAddress);
         } else {
-            if ((this.optionalParam = this
-                    .validateString("Contact",
-                            customerEntity.getReferralName(),
-                            this.MAX_LENGTH_50, false)).length() > 0) {
+            this.optionalParam = this.validateString(
+                "Contact",
+                customerEntity.getReferralName(),
+                this.MAX_LENGTH_50,
+                false);
+            if (this.optionalParam.length() > 0) {
                 customer.setContact(this.optionalParam);
             }
 
             if (customerEntity.getShippingAddress() != null) {
-                customer.getShipToAddress()
-                        .add(this
-                                .generateAddressStructure((PTAddressEntity) customerEntity
-                                        .getShippingAddress()));
+                customer
+                    .getShipToAddress()
+                    .add(this.generateAddressStructure((PTAddressEntity) customerEntity.getShippingAddress()));
             }
+
             List<PTContactEntity> contacts = customerEntity.getContacts();
             this.setContacts(customer, contacts);
 
-            final Address customerBillingAddress = customerEntity.getBillingAddress();
-            addressDetailOverride = customerBillingAddress.getDetails();
-            addressCityOverride = customerBillingAddress.getCity();
-            addressPostalCodeOverride = customerBillingAddress.getPostalCode();
-            addressCountryOverride = customerBillingAddress.getISOCountry();
-            customerId = customerEntity.getID().toString();
-        }
-        this.updateCustomerGeneralInfo(
-            customer,
-            customerId,
-            customerEntity.getTaxRegistrationNumber(),
-            customerEntity.getName(),
-            (PTAddressEntity) customerEntity.getBillingAddress(),
-            addressDetailOverride,
-            addressCityOverride,
-            addressPostalCodeOverride,
-            addressCountryOverride);
+            customer.setCustomerTaxID(this.validateString(
+                "CustomerTaxID",
+                customerEntity.getTaxRegistrationNumber(),
+                this.MAX_LENGTH_20,
+                true));
 
-        customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID,
+            customer.setCompanyName(this.validateString(
+                "CompanyName",
+                customerEntity.getName(),
+                this.MAX_LENGTH_100, true));
+
+            customer.setCustomerID(this.validateString(
+                "CustomerId",
+                customerEntity.getID().toString(),
                 this.MAX_LENGTH_30, true));
+
+            customer.setBillingAddress(this.generateAddressStructure(customerEntity.getBillingAddress()));
+        }
+
+        customer.setAccountID(this.validateString("AccountID", this.ACCOUNT_ID, this.MAX_LENGTH_30, true));
         customer.setSelfBillingIndicator(this.validateInteger(
-                "SelfBillingIndicator", this.SELF_BILLING_INDICATOR,
-                this.MAX_LENGTH_1, true));
+            "SelfBillingIndicator",
+            this.SELF_BILLING_INDICATOR,
+            this.MAX_LENGTH_1,
+            true));
 
         return customer;
     }
@@ -1221,50 +1223,6 @@ public class PTSAFTFileGenerator {
                         .toString(), document.getSeries());
 
         }
-    }
-
-    /*************
-     * CUSTOMERS *
-     *************/
-    /**
-     * Sets the main information about the Customer
-     *
-     * @param customer
-     * @param customerID
-     * @param customerFinancialID
-     *            - NIF
-     * @param companyName
-     *            - the company where the customer works
-     * @param address
-     * @throws RequiredFieldNotFoundException
-     */
-    private void updateCustomerGeneralInfo(
-        Customer customer,
-        String customerID,
-        String customerFinancialID,
-        String companyName,
-        PTAddressEntity address,
-        String addressDetailOverride,
-        String addressCityOverride,
-        String addressPostalCodeOverride,
-        String addressCountryOverride) throws RequiredFieldNotFoundException
-    {
-        customer.setCustomerTaxID(this.validateString("CustomerTaxID",
-                customerFinancialID, this.MAX_LENGTH_20, true));
-
-        customer.setCompanyName(this.validateString("CompanyName", companyName,
-                this.MAX_LENGTH_100, true));
-
-        customer.setCustomerID(this.validateString("CustomerId", customerID,
-                this.MAX_LENGTH_30, true));
-
-        final AddressStructure customerAddress = this.generateAddressStructure(address);
-        customerAddress.setAddressDetail(addressDetailOverride);
-        customerAddress.setCity(addressCityOverride);
-        customerAddress.setPostalCode(addressPostalCodeOverride);
-        customerAddress.setCountry(addressCountryOverride);
-
-        customer.setBillingAddress(customerAddress);
     }
 
     /*************


### PR DESCRIPTION
Added override for PT "Consumidor Final" address values to ensure that the values of this customer are according to the rules defined for it in SAFT documentation.