### PR TITLE
Changes DAO*CreditNoteEntryImpl to use single query

### DIFF
--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
@@ -18,9 +18,6 @@
  */
 package com.premiumminds.billy.france.persistence.dao.jpa;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
@@ -31,8 +28,10 @@ import com.premiumminds.billy.france.persistence.entities.FRCreditNoteEntryEntit
 import com.premiumminds.billy.france.persistence.entities.jpa.JPAFRCreditNoteEntity;
 import com.premiumminds.billy.france.persistence.entities.jpa.JPAFRCreditNoteEntryEntity;
 import com.premiumminds.billy.france.persistence.entities.jpa.QJPAFRCreditNoteEntity;
-import com.premiumminds.billy.france.services.entities.FRCreditNoteEntry;
+import com.premiumminds.billy.france.persistence.entities.jpa.QJPAFRCreditNoteEntryEntity;
 import com.premiumminds.billy.france.services.entities.FRInvoice;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.jpa.impl.JPAQuery;
 
 public class DAOFRCreditNoteEntryImpl
         extends AbstractDAOFRGenericInvoiceEntryImpl<FRCreditNoteEntryEntity, JPAFRCreditNoteEntryEntity>
@@ -57,19 +56,11 @@ public class DAOFRCreditNoteEntryImpl
     public FRCreditNoteEntity checkCreditNote(FRInvoice invoice) {
         QJPAFRCreditNoteEntity creditNoteEntity = QJPAFRCreditNoteEntity.jPAFRCreditNoteEntity;
 
-        List<JPAFRCreditNoteEntity> allCns = new JPAQuery<>(this.getEntityManager())
-            .from(creditNoteEntity)
-            .select(creditNoteEntity)
-            .fetch();
-
-        // TODO make a query to do this
-        for (JPAFRCreditNoteEntity cne : allCns) {
-            for (FRCreditNoteEntry cnee : cne.getEntries()) {
-                if (cnee.getReference().getNumber().compareTo(invoice.getNumber()) == 0) {
-                    return cne;
-                }
-            }
-        }
-        return null;
+        return new JPAQuery<JPAFRCreditNoteEntity>(this.getEntityManager())
+                .from(creditNoteEntity)
+                .where(new QJPAFRCreditNoteEntryEntity(JPAFRCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .reference.id.eq(invoice.getID()))
+                .select(creditNoteEntity)
+                .fetchFirst();
     }
 }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditNote.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditNote.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy france (FR Pack).
+ *
+ * billy france (FR Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy france (FR Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy france (FR Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.france.test.services.dao;
+
+import com.google.common.collect.MoreCollectors;
+import com.premiumminds.billy.france.persistence.dao.DAOFRCreditNoteEntry;
+import com.premiumminds.billy.france.persistence.entities.FRCreditNoteEntity;
+import com.premiumminds.billy.france.persistence.entities.FRInvoiceEntity;
+import com.premiumminds.billy.france.services.entities.FRCreditNote;
+import com.premiumminds.billy.france.test.FRPersistencyAbstractTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestDAOFRCreditNote extends FRPersistencyAbstractTest {
+
+    @Test
+    public void testNoCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        FRInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+
+        final DAOFRCreditNoteEntry underTest = this.getInstance(DAOFRCreditNoteEntry.class);
+
+        Assertions.assertNull(underTest.checkCreditNote(inv1));
+    }
+
+    @Test
+    public void testCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+        FRInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+        FRCreditNote ignored = this.getNewIssuedCreditnote(inv1);
+
+        final DAOFRCreditNoteEntry underTest = this.getInstance(DAOFRCreditNoteEntry.class);
+
+        final FRCreditNoteEntity actual = underTest.checkCreditNote(inv1);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(inv1.getUID(), actual.getEntries()
+                .stream()
+                .map(x -> x.getReference().getUID())
+                .collect(MoreCollectors.onlyElement()));
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/jpa/DAOPTCreditNoteEntryImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/jpa/DAOPTCreditNoteEntryImpl.java
@@ -18,9 +18,6 @@
  */
 package com.premiumminds.billy.portugal.persistence.dao.jpa;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
@@ -31,8 +28,10 @@ import com.premiumminds.billy.portugal.persistence.entities.PTCreditNoteEntryEnt
 import com.premiumminds.billy.portugal.persistence.entities.jpa.JPAPTCreditNoteEntity;
 import com.premiumminds.billy.portugal.persistence.entities.jpa.JPAPTCreditNoteEntryEntity;
 import com.premiumminds.billy.portugal.persistence.entities.jpa.QJPAPTCreditNoteEntity;
-import com.premiumminds.billy.portugal.services.entities.PTCreditNoteEntry;
+import com.premiumminds.billy.portugal.persistence.entities.jpa.QJPAPTCreditNoteEntryEntity;
 import com.premiumminds.billy.portugal.services.entities.PTInvoice;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.jpa.impl.JPAQuery;
 
 public class DAOPTCreditNoteEntryImpl
         extends AbstractDAOPTGenericInvoiceEntryImpl<PTCreditNoteEntryEntity, JPAPTCreditNoteEntryEntity>
@@ -58,20 +57,11 @@ public class DAOPTCreditNoteEntryImpl
 
         QJPAPTCreditNoteEntity creditNoteEntity = QJPAPTCreditNoteEntity.jPAPTCreditNoteEntity;
 
-        JPAQuery<PTCreditNoteEntity> query = new JPAQuery<>(this.getEntityManager());
-
-        query.from(creditNoteEntity);
-
-        List<JPAPTCreditNoteEntity> allCns = query.select(creditNoteEntity).fetch();
-
-        // TODO make a query to do this
-        for (JPAPTCreditNoteEntity cne : allCns) {
-            for (PTCreditNoteEntry cnee : cne.getEntries()) {
-                if (cnee.getReference().getNumber().compareTo(invoice.getNumber()) == 0) {
-                    return cne;
-                }
-            }
-        }
-        return null;
+        return new JPAQuery<JPAPTCreditNoteEntity>(this.getEntityManager())
+                .from(creditNoteEntity)
+                .where(new QJPAPTCreditNoteEntryEntity(JPAPTCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .reference.id.eq(invoice.getID()))
+                .select(creditNoteEntity)
+                .fetchFirst();
     }
 }

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTCreditNote.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTCreditNote.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.test.services.dao;
+
+import com.google.common.collect.MoreCollectors;
+import com.premiumminds.billy.portugal.persistence.dao.DAOPTCreditNoteEntry;
+import com.premiumminds.billy.portugal.persistence.entities.PTCreditNoteEntity;
+import com.premiumminds.billy.portugal.persistence.entities.PTInvoiceEntity;
+import com.premiumminds.billy.portugal.services.entities.PTCreditNote;
+import com.premiumminds.billy.portugal.test.PTPersistencyAbstractTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestDAOPTCreditNote extends PTPersistencyAbstractTest {
+
+    @Test
+    public void testNoCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        PTInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+
+        final DAOPTCreditNoteEntry underTest = this.getInstance(DAOPTCreditNoteEntry.class);
+
+        Assertions.assertNull(underTest.checkCreditNote(inv1));
+    }
+
+    @Test
+    public void testCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+        PTInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+        PTCreditNote ignored = this.getNewIssuedCreditnote(inv1);
+
+        final DAOPTCreditNoteEntry underTest = this.getInstance(DAOPTCreditNoteEntry.class);
+
+        final PTCreditNoteEntity actual = underTest.checkCreditNote(inv1);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(inv1.getUID(), actual.getEntries()
+                .stream()
+                .map(x -> x.getReference().getUID())
+                .collect(MoreCollectors.onlyElement()));
+    }
+
+}

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
@@ -18,9 +18,6 @@
  */
 package com.premiumminds.billy.spain.persistence.dao.jpa;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
@@ -31,8 +28,10 @@ import com.premiumminds.billy.spain.persistence.entities.ESCreditNoteEntryEntity
 import com.premiumminds.billy.spain.persistence.entities.jpa.JPAESCreditNoteEntity;
 import com.premiumminds.billy.spain.persistence.entities.jpa.JPAESCreditNoteEntryEntity;
 import com.premiumminds.billy.spain.persistence.entities.jpa.QJPAESCreditNoteEntity;
-import com.premiumminds.billy.spain.services.entities.ESCreditNoteEntry;
+import com.premiumminds.billy.spain.persistence.entities.jpa.QJPAESCreditNoteEntryEntity;
 import com.premiumminds.billy.spain.services.entities.ESInvoice;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.jpa.impl.JPAQuery;
 
 public class DAOESCreditNoteEntryImpl
         extends AbstractDAOESGenericInvoiceEntryImpl<ESCreditNoteEntryEntity, JPAESCreditNoteEntryEntity>
@@ -57,19 +56,11 @@ public class DAOESCreditNoteEntryImpl
     public ESCreditNoteEntity checkCreditNote(ESInvoice invoice) {
         QJPAESCreditNoteEntity creditNoteEntity = QJPAESCreditNoteEntity.jPAESCreditNoteEntity;
 
-        List<JPAESCreditNoteEntity> allCns = new JPAQuery<>(this.getEntityManager())
-            .select(creditNoteEntity)
-            .from(creditNoteEntity)
-            .fetch();
-
-        // TODO make a query to do this
-        for (JPAESCreditNoteEntity cne : allCns) {
-            for (ESCreditNoteEntry cnee : cne.getEntries()) {
-                if (cnee.getReference().getNumber().compareTo(invoice.getNumber()) == 0) {
-                    return cne;
-                }
-            }
-        }
-        return null;
+        return new JPAQuery<JPAESCreditNoteEntity>(this.getEntityManager())
+                .from(creditNoteEntity)
+                .where(new QJPAESCreditNoteEntryEntity(JPAESCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .reference.id.eq(invoice.getID()))
+                .select(creditNoteEntity)
+                .fetchFirst();
     }
 }

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditNote.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditNote.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy spain (ES Pack).
+ *
+ * billy spain (ES Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy spain (ES Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy spain (ES Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.spain.test.services.dao;
+
+import com.google.common.collect.MoreCollectors;
+import com.premiumminds.billy.spain.persistence.dao.DAOESCreditNoteEntry;
+import com.premiumminds.billy.spain.persistence.entities.ESCreditNoteEntity;
+import com.premiumminds.billy.spain.persistence.entities.ESInvoiceEntity;
+import com.premiumminds.billy.spain.services.entities.ESCreditNote;
+import com.premiumminds.billy.spain.test.ESPersistencyAbstractTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestDAOESCreditNote extends ESPersistencyAbstractTest {
+
+    @Test
+    public void testNoCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        ESInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+
+        final DAOESCreditNoteEntry underTest = this.getInstance(DAOESCreditNoteEntry.class);
+
+        Assertions.assertNull(underTest.checkCreditNote(inv1));
+    }
+
+    @Test
+    public void testCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+        ESInvoiceEntity inv1 = this.getNewIssuedInvoice(B1);
+        ESCreditNote ignored = this.getNewIssuedCreditnote(inv1);
+
+        final DAOESCreditNoteEntry underTest = this.getInstance(DAOESCreditNoteEntry.class);
+
+        final ESCreditNoteEntity actual = underTest.checkCreditNote(inv1);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(inv1.getUID(), actual.getEntries()
+                .stream()
+                .map(x -> x.getReference().getUID())
+                .collect(MoreCollectors.onlyElement()));
+    }
+}


### PR DESCRIPTION
Obtaining all credit notes and iterating over them was executing 1+N queries and was getting worse results as more and more credit notes were being issued.

fixes #377 