### PR TITLE
Changes DAO*CreditReceiptEntryImpl to use single query

### DIFF
--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
@@ -59,7 +59,7 @@ public class DAOFRCreditNoteEntryImpl
         return new JPAQuery<JPAFRCreditNoteEntity>(this.getEntityManager())
                 .from(creditNoteEntity)
                 .where(new QJPAFRCreditNoteEntryEntity(JPAFRCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
-                        .reference.id.eq(invoice.getID()))
+                        .invoiceReference.id.eq(invoice.getID()))
                 .select(creditNoteEntity)
                 .fetchFirst();
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteImpl.java
@@ -69,7 +69,7 @@ public class DAOFRCreditNoteImpl extends AbstractDAOFRGenericInvoiceImpl<FRCredi
         final JPQLQuery<String> entQ = JPAExpressions
             .select(entry.uid)
             .from(entry)
-            .where(this.toDSL(entry.reference, QJPAFRGenericInvoiceEntity.class).uid.in(invQ));
+            .where(this.toDSL(entry.invoiceReference, QJPAFRGenericInvoiceEntity.class).uid.in(invQ));
 
         return new ArrayList<>(this
             .createQuery()

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptEntryImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptEntryImpl.java
@@ -18,9 +18,6 @@
  */
 package com.premiumminds.billy.france.persistence.dao.jpa;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
@@ -31,8 +28,10 @@ import com.premiumminds.billy.france.persistence.entities.FRCreditReceiptEntryEn
 import com.premiumminds.billy.france.persistence.entities.jpa.JPAFRCreditReceiptEntity;
 import com.premiumminds.billy.france.persistence.entities.jpa.JPAFRCreditReceiptEntryEntity;
 import com.premiumminds.billy.france.persistence.entities.jpa.QJPAFRCreditReceiptEntity;
-import com.premiumminds.billy.france.services.entities.FRCreditReceiptEntry;
+import com.premiumminds.billy.france.persistence.entities.jpa.QJPAFRCreditReceiptEntryEntity;
 import com.premiumminds.billy.france.services.entities.FRReceipt;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.jpa.impl.JPAQuery;
 
 public class DAOFRCreditReceiptEntryImpl
         extends AbstractDAOFRGenericInvoiceEntryImpl<FRCreditReceiptEntryEntity, JPAFRCreditReceiptEntryEntity>
@@ -57,19 +56,11 @@ public class DAOFRCreditReceiptEntryImpl
     public FRCreditReceiptEntity checkCreditReceipt(FRReceipt receipt) {
         QJPAFRCreditReceiptEntity creditReceiptEntity = QJPAFRCreditReceiptEntity.jPAFRCreditReceiptEntity;
 
-        List<JPAFRCreditReceiptEntity> allCns = new JPAQuery<>(this.getEntityManager())
-            .select(creditReceiptEntity)
-            .from(creditReceiptEntity)
-            .fetch();
-
-        // TODO make a query to do this
-        for (JPAFRCreditReceiptEntity cne : allCns) {
-            for (FRCreditReceiptEntry cnee : cne.getEntries()) {
-                if (cnee.getReference().getNumber().compareTo(receipt.getNumber()) == 0) {
-                    return cne;
-                }
-            }
-        }
-        return null;
+        return new JPAQuery<JPAFRCreditReceiptEntity>(this.getEntityManager())
+                .from(creditReceiptEntity)
+                .where(new QJPAFRCreditReceiptEntryEntity(JPAFRCreditReceiptEntryEntity.class, creditReceiptEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .receiptReference.id.eq(receipt.getID()))
+                .select(creditReceiptEntity)
+                .fetchFirst();
     }
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptImpl.java
@@ -69,7 +69,7 @@ public class DAOFRCreditReceiptImpl extends
         final JPQLQuery<String> entQ = JPAExpressions
             .select(entry.uid)
             .from(entry)
-            .where(this.toDSL(entry.reference, QJPAFRGenericInvoiceEntity.class).uid.in(invQ));
+            .where(this.toDSL(entry.receiptReference, QJPAFRGenericInvoiceEntity.class).uid.in(invQ));
 
         return new ArrayList<>(this
             .createQuery()

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/entities/jpa/JPAFRCreditNoteEntryEntity.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/entities/jpa/JPAFRCreditNoteEntryEntity.java
@@ -45,7 +45,7 @@ public class JPAFRCreditNoteEntryEntity extends JPAFRGenericInvoiceEntryEntity i
     @OneToOne(fetch = FetchType.EAGER, targetEntity = JPAFRInvoiceEntity.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinColumn(name = "ID_FRINVOICE", referencedColumnName = "ID")
-    protected FRInvoice reference;
+    protected FRInvoice invoiceReference;
 
     @Column(name = "REASON")
     protected String reason;
@@ -57,12 +57,12 @@ public class JPAFRCreditNoteEntryEntity extends JPAFRGenericInvoiceEntryEntity i
 
     @Override
     public FRInvoice getReference() {
-        return this.reference;
+        return this.invoiceReference;
     }
 
     @Override
     public void setReference(FRInvoice reference) {
-        this.reference = reference;
+        this.invoiceReference = reference;
     }
 
     @Override

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/entities/jpa/JPAFRCreditReceiptEntryEntity.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/entities/jpa/JPAFRCreditReceiptEntryEntity.java
@@ -46,7 +46,7 @@ public class JPAFRCreditReceiptEntryEntity extends JPAFRGenericInvoiceEntryEntit
     @OneToOne(fetch = FetchType.EAGER, targetEntity = JPAFRReceiptEntity.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinColumn(name = "ID_FRRECEIPT", referencedColumnName = "ID")
-    protected FRReceipt reference;
+    protected FRReceipt receiptReference;
 
     @Column(name = "REASON")
     protected String reason;
@@ -58,12 +58,12 @@ public class JPAFRCreditReceiptEntryEntity extends JPAFRGenericInvoiceEntryEntit
 
     @Override
     public FRReceipt getReference() {
-        return this.reference;
+        return this.receiptReference;
     }
 
     @Override
     public void setReference(FRReceipt reference) {
-        this.reference = reference;
+        this.receiptReference = reference;
     }
 
     @Override

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/FRPersistencyAbstractTest.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/FRPersistencyAbstractTest.java
@@ -21,6 +21,9 @@ package com.premiumminds.billy.france.test;
 import com.premiumminds.billy.core.exceptions.SeriesUniqueCodeNotFilled;
 import com.premiumminds.billy.core.persistence.dao.DAOInvoiceSeries;
 import com.premiumminds.billy.core.services.exceptions.DocumentSeriesDoesNotExistException;
+import com.premiumminds.billy.france.persistence.entities.FRCreditReceiptEntity;
+import com.premiumminds.billy.france.services.entities.FRReceipt;
+import com.premiumminds.billy.france.test.util.FRCreditReceiptTestUtil;
 import com.premiumminds.billy.persistence.entities.jpa.JPAInvoiceSeriesEntity;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
 import org.junit.jupiter.api.AfterEach;
@@ -99,6 +102,25 @@ public class FRPersistencyAbstractTest extends FRAbstractTest {
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
             e.printStackTrace();
         }
+      return null;
+    }
+
+    public FRCreditReceiptEntity getNewIssuedCreditReceipt(FRReceipt receipt) {
+        Services service = new Services(FRAbstractTest.injector);
+        FRIssuingParams parameters = new FRIssuingParamsImpl();
+
+        parameters = this.getParameters("RC", "30000");
+
+        this.createSeries(receipt, "RC");
+
+        try {
+            return (FRCreditReceiptEntity) service.issueDocument(
+                    new FRCreditReceiptTestUtil(FRAbstractTest.injector).getCreditReceiptBuilder((FRReceiptEntity) receipt),
+                    parameters);
+        } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
+            e.printStackTrace();
+        }
+
         return null;
     }
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditReceipt.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditReceipt.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy france (FR Pack).
+ *
+ * billy france (FR Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy france (FR Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy france (FR Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.france.test.services.dao;
+
+import com.google.common.collect.MoreCollectors;
+import com.premiumminds.billy.france.persistence.dao.DAOFRCreditReceiptEntry;
+import com.premiumminds.billy.france.persistence.entities.FRCreditReceiptEntity;
+import com.premiumminds.billy.france.persistence.entities.FRReceiptEntity;
+import com.premiumminds.billy.france.test.FRPersistencyAbstractTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestDAOFRCreditReceipt extends FRPersistencyAbstractTest {
+
+    @Test
+    public void testNoCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        FRReceiptEntity rec1 = this.getNewIssuedReceipt("B1");
+
+        final DAOFRCreditReceiptEntry underTest = this.getInstance(DAOFRCreditReceiptEntry.class);
+
+        Assertions.assertNull(underTest.checkCreditReceipt(rec1));
+    }
+
+    @Test
+    public void testCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        FRReceiptEntity rec1 = this.getNewIssuedReceipt(B1);
+        FRCreditReceiptEntity ignored = this.getNewIssuedCreditReceipt(rec1);
+
+        final DAOFRCreditReceiptEntry underTest = this.getInstance(DAOFRCreditReceiptEntry.class);
+
+        final FRCreditReceiptEntity actual = underTest.checkCreditReceipt(rec1);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(rec1.getUID(), actual.getEntries()
+                .stream()
+                .map(x -> x.getReference().getUID())
+                .collect(MoreCollectors.onlyElement()));
+    }
+}

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
@@ -59,7 +59,7 @@ public class DAOESCreditNoteEntryImpl
         return new JPAQuery<JPAESCreditNoteEntity>(this.getEntityManager())
                 .from(creditNoteEntity)
                 .where(new QJPAESCreditNoteEntryEntity(JPAESCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
-                        .reference.id.eq(invoice.getID()))
+                        .invoiceReference.id.eq(invoice.getID()))
                 .select(creditNoteEntity)
                 .fetchFirst();
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteImpl.java
@@ -69,7 +69,7 @@ public class DAOESCreditNoteImpl extends AbstractDAOESGenericInvoiceImpl<ESCredi
         final JPQLQuery<String> entQ = JPAExpressions
             .select(entry.uid)
             .from(entry)
-            .where(this.toDSL(entry.reference, QJPAESGenericInvoiceEntity.class).uid.in(invQ));
+            .where(this.toDSL(entry.invoiceReference, QJPAESGenericInvoiceEntity.class).uid.in(invQ));
 
         return new ArrayList<>(this
             .createQuery()

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptEntryImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptEntryImpl.java
@@ -18,9 +18,6 @@
  */
 package com.premiumminds.billy.spain.persistence.dao.jpa;
 
-import com.querydsl.jpa.impl.JPAQuery;
-import java.util.List;
-
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.persistence.EntityManager;
@@ -31,8 +28,10 @@ import com.premiumminds.billy.spain.persistence.entities.ESCreditReceiptEntryEnt
 import com.premiumminds.billy.spain.persistence.entities.jpa.JPAESCreditReceiptEntity;
 import com.premiumminds.billy.spain.persistence.entities.jpa.JPAESCreditReceiptEntryEntity;
 import com.premiumminds.billy.spain.persistence.entities.jpa.QJPAESCreditReceiptEntity;
-import com.premiumminds.billy.spain.services.entities.ESCreditReceiptEntry;
+import com.premiumminds.billy.spain.persistence.entities.jpa.QJPAESCreditReceiptEntryEntity;
 import com.premiumminds.billy.spain.services.entities.ESReceipt;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.jpa.impl.JPAQuery;
 
 public class DAOESCreditReceiptEntryImpl
         extends AbstractDAOESGenericInvoiceEntryImpl<ESCreditReceiptEntryEntity, JPAESCreditReceiptEntryEntity>
@@ -57,19 +56,11 @@ public class DAOESCreditReceiptEntryImpl
     public ESCreditReceiptEntity checkCreditReceipt(ESReceipt receipt) {
         QJPAESCreditReceiptEntity creditReceiptEntity = QJPAESCreditReceiptEntity.jPAESCreditReceiptEntity;
 
-        List<JPAESCreditReceiptEntity> allCns = new JPAQuery<>(this.getEntityManager())
-            .from(creditReceiptEntity)
-            .select(creditReceiptEntity)
-            .fetch();
-
-        // TODO make a query to do this
-        for (JPAESCreditReceiptEntity cne : allCns) {
-            for (ESCreditReceiptEntry cnee : cne.getEntries()) {
-                if (cnee.getReference().getNumber().compareTo(receipt.getNumber()) == 0) {
-                    return cne;
-                }
-            }
-        }
-        return null;
+        return new JPAQuery<JPAESCreditReceiptEntity>(this.getEntityManager())
+                .from(creditReceiptEntity)
+                .where(new QJPAESCreditReceiptEntryEntity(JPAESCreditReceiptEntryEntity.class, creditReceiptEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .receiptReference.id.eq(receipt.getID()))
+                .select(creditReceiptEntity)
+                .fetchFirst();
     }
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptImpl.java
@@ -69,7 +69,7 @@ public class DAOESCreditReceiptImpl extends
         final JPQLQuery<String> entQ = JPAExpressions
             .select(entry.uid)
             .from(entry)
-            .where(this.toDSL(entry.reference, QJPAESGenericInvoiceEntity.class).uid.in(invQ));
+            .where(this.toDSL(entry.receiptReference, QJPAESGenericInvoiceEntity.class).uid.in(invQ));
 
         return new ArrayList<>(this
             .createQuery()

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/entities/jpa/JPAESCreditNoteEntryEntity.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/entities/jpa/JPAESCreditNoteEntryEntity.java
@@ -45,7 +45,7 @@ public class JPAESCreditNoteEntryEntity extends JPAESGenericInvoiceEntryEntity i
     @OneToOne(fetch = FetchType.EAGER, targetEntity = JPAESInvoiceEntity.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinColumn(name = "ID_ESINVOICE", referencedColumnName = "ID")
-    protected ESInvoice reference;
+    protected ESInvoice invoiceReference;
 
     @Column(name = "REASON")
     protected String reason;
@@ -57,12 +57,12 @@ public class JPAESCreditNoteEntryEntity extends JPAESGenericInvoiceEntryEntity i
 
     @Override
     public ESInvoice getReference() {
-        return this.reference;
+        return this.invoiceReference;
     }
 
     @Override
     public void setReference(ESInvoice reference) {
-        this.reference = reference;
+        this.invoiceReference = reference;
     }
 
     @Override

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/entities/jpa/JPAESCreditReceiptEntryEntity.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/entities/jpa/JPAESCreditReceiptEntryEntity.java
@@ -46,7 +46,7 @@ public class JPAESCreditReceiptEntryEntity extends JPAESGenericInvoiceEntryEntit
     @OneToOne(fetch = FetchType.EAGER, targetEntity = JPAESReceiptEntity.class,
             cascade = { CascadeType.PERSIST, CascadeType.MERGE })
     @JoinColumn(name = "ID_ESRECEIPT", referencedColumnName = "ID")
-    protected ESReceipt reference;
+    protected ESReceipt receiptReference;
 
     @Column(name = "REASON")
     protected String reason;
@@ -58,12 +58,12 @@ public class JPAESCreditReceiptEntryEntity extends JPAESGenericInvoiceEntryEntit
 
     @Override
     public ESReceipt getReference() {
-        return this.reference;
+        return this.receiptReference;
     }
 
     @Override
     public void setReference(ESReceipt reference) {
-        this.reference = reference;
+        this.receiptReference = reference;
     }
 
     @Override

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/ESPersistencyAbstractTest.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/ESPersistencyAbstractTest.java
@@ -23,6 +23,9 @@ import com.premiumminds.billy.core.persistence.dao.DAOInvoiceSeries;
 import com.premiumminds.billy.core.services.exceptions.DocumentSeriesDoesNotExistException;
 import com.premiumminds.billy.persistence.entities.jpa.JPAInvoiceSeriesEntity;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
+import com.premiumminds.billy.spain.persistence.entities.ESCreditReceiptEntity;
+import com.premiumminds.billy.spain.services.entities.ESReceipt;
+import com.premiumminds.billy.spain.test.util.ESCreditReceiptTestUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -99,6 +102,25 @@ public class ESPersistencyAbstractTest extends ESAbstractTest {
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
             e.printStackTrace();
         }
+        return null;
+    }
+
+    public ESCreditReceiptEntity getNewIssuedCreditReceipt(ESReceipt receipt) {
+        Services service = new Services(ESAbstractTest.injector);
+        ESIssuingParams parameters = new ESIssuingParamsImpl();
+
+        parameters = this.getParameters("RC", "30000");
+
+        this.createSeries(receipt, "RC");
+
+        try {
+            return (ESCreditReceiptEntity) service.issueDocument(
+                    new ESCreditReceiptTestUtil(ESAbstractTest.injector).getCreditReceiptBuilder((ESReceiptEntity) receipt),
+                    parameters);
+        } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
+            e.printStackTrace();
+        }
+
         return null;
     }
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditReceipt.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditReceipt.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy spain (ES Pack).
+ *
+ * billy spain (ES Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy spain (ES Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy spain (ES Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.spain.test.services.dao;
+
+import com.google.common.collect.MoreCollectors;
+import com.premiumminds.billy.spain.persistence.dao.DAOESCreditReceiptEntry;
+import com.premiumminds.billy.spain.persistence.entities.ESCreditReceiptEntity;
+import com.premiumminds.billy.spain.persistence.entities.ESReceiptEntity;
+import com.premiumminds.billy.spain.test.ESPersistencyAbstractTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TestDAOESCreditReceipt extends ESPersistencyAbstractTest {
+
+    @Test
+    public void testNoCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        ESReceiptEntity rec1 = this.getNewIssuedReceipt("B1");
+
+        final DAOESCreditReceiptEntry underTest = this.getInstance(DAOESCreditReceiptEntry.class);
+
+        Assertions.assertNull(underTest.checkCreditReceipt(rec1));
+    }
+
+    @Test
+    public void testCreditEntriesForInvoice() {
+        String B1 = "B1";
+        this.createSeries(B1);
+
+        ESReceiptEntity rec1 = this.getNewIssuedReceipt(B1);
+        ESCreditReceiptEntity ignored = this.getNewIssuedCreditReceipt(rec1);
+
+        final DAOESCreditReceiptEntry underTest = this.getInstance(DAOESCreditReceiptEntry.class);
+
+        final ESCreditReceiptEntity actual = underTest.checkCreditReceipt(rec1);
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(rec1.getUID(), actual.getEntries()
+                .stream()
+                .map(x -> x.getReference().getUID())
+                .collect(MoreCollectors.onlyElement()));
+    }
+}


### PR DESCRIPTION
Obtaining all credit receipts and iterating over them was executing 1+N queries and was getting worse results as more and more credit receipts were being issued.

Both subtypes JPAESCreditReceiptEntryEntity and JPAESCreditNoteEntryEntity of JPAESGenericInvoiceEntryEntity have a field with the same name: reference that confuses Hibernate. This actually throws an exception with Hibernate v6.

Renamed field reference in both subtypes to workaround the problem.

fixes #381  