### PR TITLE
Remove tax detail override in simple invoice and receipt invoice

### DIFF
--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/export/pdf/simpleinvoice/impl/ADSimpleInvoicePDFFOPTransformer.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/export/pdf/simpleinvoice/impl/ADSimpleInvoicePDFFOPTransformer.java
@@ -78,13 +78,7 @@ public class ADSimpleInvoicePDFFOPTransformer extends ADAbstractFOPPDFTransforme
     }
 
     @Override
-    protected void setTaxDetails(TaxTotals taxTotals, ParamsTree<String, String> params) {
-        // Do nothing
-    }
-
-    @Override
     public String getCustomerFinancialId(ADSimpleInvoiceData entity) {
         return entity.getCustomer().getTaxRegistrationNumber();
     }
-
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/export/pdf/simpleinvoice/impl/FRSimpleInvoicePDFFOPTransformer.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/export/pdf/simpleinvoice/impl/FRSimpleInvoicePDFFOPTransformer.java
@@ -77,13 +77,7 @@ public class FRSimpleInvoicePDFFOPTransformer extends FRAbstractFOPPDFTransforme
     }
 
     @Override
-    protected void setTaxDetails(TaxTotals taxTotals, ParamsTree<String, String> params) {
-        // Do nothing
-    }
-
-    @Override
     public String getCustomerFinancialId(FRSimpleInvoiceData entity) {
         return entity.getCustomer().getTaxRegistrationNumber();
     }
-
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/pdf/receiptinvoice/PTReceiptInvoicePDFFOPTransformer.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/pdf/receiptinvoice/PTReceiptInvoicePDFFOPTransformer.java
@@ -87,10 +87,4 @@ public class PTReceiptInvoicePDFFOPTransformer extends PTAbstractFOPPDFTransform
 
         customer.addChild(ParamKeys.CUSTOMER_FINANCIAL_ID, this.getCustomerFinancialId(document));
     }
-
-    @Override
-    protected void setTaxDetails(TaxTotals taxTotals, ParamsTree<String, String> params) {
-        // Do nothing
-    }
-
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/pdf/simpleinvoice/PTSimpleInvoicePDFFOPTransformer.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/pdf/simpleinvoice/PTSimpleInvoicePDFFOPTransformer.java
@@ -87,10 +87,4 @@ public class PTSimpleInvoicePDFFOPTransformer extends PTAbstractFOPPDFTransforme
 
         customer.addChild(ParamKeys.CUSTOMER_FINANCIAL_ID, this.getCustomerFinancialId(entity));
     }
-
-    @Override
-    protected void setTaxDetails(TaxTotals taxTotals, ParamsTree<String, String> params) {
-        // Do Nothing
-    }
-
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/export/pdf/simpleinvoice/impl/ESSimpleInvoicePDFFOPTransformer.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/export/pdf/simpleinvoice/impl/ESSimpleInvoicePDFFOPTransformer.java
@@ -75,15 +75,8 @@ public class ESSimpleInvoicePDFFOPTransformer extends ESAbstractFOPPDFTransforme
         Node<String, String> customer = params.getRoot().addChild(ParamKeys.CUSTOMER);
         customer.addChild(ParamKeys.CUSTOMER_FINANCIAL_ID, this.getCustomerFinancialId(entity));
     }
-
-    @Override
-    protected void setTaxDetails(TaxTotals taxTotals, ParamsTree<String, String> params) {
-        // Do nothing
-    }
-
     @Override
     public String getCustomerFinancialId(ESSimpleInvoiceData entity) {
         return entity.getCustomer().getTaxRegistrationNumber();
     }
-
 }


### PR DESCRIPTION
transformers

Since the setTaxDetails(...) method was being overriden by an empty implementation for simple invoices and receipt invoices, this meant that, unlike other document types, we were not exposing any info regarding the various tax rates and values included in the document for use while templating.