### PR TITLE
Changes sorting of invoices entries to be performed on a temporary list

### DIFF
--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_02_01/PTSAFTFileGenerator.java
@@ -787,9 +787,10 @@ public class PTSAFTFileGenerator {
             throw new RequiredFieldNotFoundException(this.context + " Line");
         }
 
-        entries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
+        final ArrayList<PTGenericInvoiceEntryEntity> sortedEntries = new ArrayList<>(entries);
+        sortedEntries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
 
-        for (PTGenericInvoiceEntryEntity entry : entries) {
+        for (PTGenericInvoiceEntryEntity entry : sortedEntries) {
             /* REQUIRED - One Invoice.Line per IPTFinancialDocumentEntryEntity */
             Line line = new Line();
             line.setLineNumber(new BigInteger(Integer.toString(entry.getEntryNumber())));

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_03_01/PTSAFTFileGenerator.java
@@ -812,9 +812,10 @@ public class PTSAFTFileGenerator {
             throw new RequiredFieldNotFoundException(this.context + " Line");
         }
 
-        entries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
+        final ArrayList<PTGenericInvoiceEntryEntity> sortedEntries = new ArrayList<>(entries);
+        sortedEntries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
 
-        for (PTGenericInvoiceEntryEntity entry : entries) {
+        for (PTGenericInvoiceEntryEntity entry : sortedEntries) {
             /* REQUIRED - One Invoice.Line per IPTFinancialDocumentEntryEntity */
             Line line = new Line();
             line.setLineNumber(new BigInteger(Integer.toString(entry.getEntryNumber())));

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/saftpt/v1_04_01/PTSAFTFileGenerator.java
@@ -881,9 +881,10 @@ public class PTSAFTFileGenerator {
             throw new RequiredFieldNotFoundException(this.context + " Line");
         }
 
-        entries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
+        final ArrayList<PTGenericInvoiceEntryEntity> sortedEntries = new ArrayList<>(entries);
+        sortedEntries.sort(Comparator.comparing(GenericInvoiceEntry::getEntryNumber));
 
-        for (PTGenericInvoiceEntryEntity entry : entries) {
+        for (PTGenericInvoiceEntryEntity entry : sortedEntries) {
             /* REQUIRED - One Invoice.Line per IPTFinancialDocumentEntryEntity */
             Line line = new Line();
             line.setLineNumber(new BigInteger(Integer.toString(entry


### PR DESCRIPTION
This way, it avoids Hibernate attempting to update the entries order by performing lots of deletes and inserts.

fixes #409 