### PR TITLE
Adds new method to check for existence of credit notes

### DIFF
--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/DAOADCreditNoteEntry.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/DAOADCreditNoteEntry.java
@@ -26,4 +26,6 @@ public interface DAOADCreditNoteEntry extends AbstractDAOADGenericInvoiceEntry<A
 
     public ADCreditNoteEntity checkCreditNote(ADInvoice invoice);
 
+    public boolean existsCreditNote(ADInvoice invoice);
+
 }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/DAOADCreditReceiptEntry.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/DAOADCreditReceiptEntry.java
@@ -26,4 +26,5 @@ public interface DAOADCreditReceiptEntry extends AbstractDAOADGenericInvoiceEntr
 
     public ADCreditReceiptEntity checkCreditReceipt(ADReceipt invoice);
 
+    public boolean existsCreditReceipt(ADReceipt invoice);
 }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/jpa/DAOADCreditNoteEntryImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/jpa/DAOADCreditNoteEntryImpl.java
@@ -64,4 +64,16 @@ public class DAOADCreditNoteEntryImpl
                 .select(creditNoteEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditNote(ADInvoice invoice) {
+        QJPAADCreditNoteEntity creditNoteEntity = QJPAADCreditNoteEntity.jPAADCreditNoteEntity;
+
+        return new JPAQuery<JPAADCreditNoteEntity>(this.getEntityManager())
+            .from(creditNoteEntity)
+            .where(new QJPAADCreditNoteEntryEntity(JPAADCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                       .invoiceReference.id.eq(invoice.getID()))
+            .select(creditNoteEntity.id)
+            .fetchFirst() != null;
+    }
 }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/jpa/DAOADCreditReceiptEntryImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/persistence/dao/jpa/DAOADCreditReceiptEntryImpl.java
@@ -64,4 +64,16 @@ public class DAOADCreditReceiptEntryImpl
                 .select(creditReceiptEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditReceipt(ADReceipt receipt) {
+        QJPAADCreditReceiptEntity creditReceiptEntity = QJPAADCreditReceiptEntity.jPAADCreditReceiptEntity;
+
+        return new JPAQuery<JPAADCreditReceiptEntity>(this.getEntityManager())
+                .from(creditReceiptEntity)
+                .where(new QJPAADCreditReceiptEntryEntity(JPAADCreditReceiptEntryEntity.class, creditReceiptEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .receiptReference.id.eq(receipt.getID()))
+                .select(creditReceiptEntity.id)
+                .fetchFirst() != null;
+    }
 }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADCreditNoteEntryBuilderImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADCreditNoteEntryBuilderImpl.java
@@ -88,7 +88,7 @@ public class ADCreditNoteEntryBuilderImpl<TBuilder extends ADCreditNoteEntryBuil
     }
 
     private void ValidateADCreditNoteEntry(ADCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADCreditReceiptEntryBuilderImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADCreditReceiptEntryBuilderImpl.java
@@ -88,7 +88,7 @@ public class ADCreditReceiptEntryBuilderImpl<TBuilder extends ADCreditReceiptEnt
     }
 
     private void ValidateESCreditReceiptEntry(ADCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADManualCreditNoteEntryBuilderImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADManualCreditNoteEntryBuilderImpl.java
@@ -101,7 +101,7 @@ public class ADManualCreditNoteEntryBuilderImpl<TBuilder extends ADManualCreditN
     }
 
     private void ValidateESCreditNoteEntry(ADCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADManualCreditReceiptEntryBuilderImpl.java
+++ b/billy-andorra/src/main/java/com/premiumminds/billy/andorra/services/builders/impl/ADManualCreditReceiptEntryBuilderImpl.java
@@ -100,7 +100,7 @@ public class ADManualCreditReceiptEntryBuilderImpl<TBuilder extends ADManualCred
     }
 
     private void ValidateESCreditReceiptEntry(ADCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/dao/TestDAOADCreditNote.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/dao/TestDAOADCreditNote.java
@@ -42,6 +42,7 @@ public class TestDAOADCreditNote extends ADPersistencyAbstractTest {
         final DAOADCreditNoteEntry underTest = this.getInstance(DAOADCreditNoteEntry.class);
 
         Assertions.assertNull(underTest.checkCreditNote(inv1));
+        Assertions.assertFalse(underTest.existsCreditNote(inv1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOADCreditNote extends ADPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditNote(inv1));
     }
 }

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/dao/TestDAOADCreditReceipt.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/dao/TestDAOADCreditReceipt.java
@@ -41,6 +41,7 @@ public class TestDAOADCreditReceipt extends ADPersistencyAbstractTest {
         final DAOADCreditReceiptEntry underTest = this.getInstance(DAOADCreditReceiptEntry.class);
 
         Assertions.assertNull(underTest.checkCreditReceipt(rec1));
+        Assertions.assertFalse(underTest.existsCreditReceipt(rec1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOADCreditReceipt extends ADPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditReceipt(rec1));
     }
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRCreditNoteEntry.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRCreditNoteEntry.java
@@ -26,4 +26,6 @@ public interface DAOFRCreditNoteEntry extends AbstractDAOFRGenericInvoiceEntry<F
 
     public FRCreditNoteEntity checkCreditNote(FRInvoice invoice);
 
+    public boolean existsCreditNote(FRInvoice invoice);
+
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRCreditReceiptEntry.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/DAOFRCreditReceiptEntry.java
@@ -26,4 +26,6 @@ public interface DAOFRCreditReceiptEntry extends AbstractDAOFRGenericInvoiceEntr
 
     public FRCreditReceiptEntity checkCreditReceipt(FRReceipt invoice);
 
+    public boolean existsCreditReceipt(FRReceipt invoice);
+
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditNoteEntryImpl.java
@@ -63,4 +63,16 @@ public class DAOFRCreditNoteEntryImpl
                 .select(creditNoteEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditNote(FRInvoice invoice) {
+        QJPAFRCreditNoteEntity creditNoteEntity = QJPAFRCreditNoteEntity.jPAFRCreditNoteEntity;
+
+        return new JPAQuery<JPAFRCreditNoteEntity>(this.getEntityManager())
+            .from(creditNoteEntity)
+            .where(new QJPAFRCreditNoteEntryEntity(JPAFRCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                       .invoiceReference.id.eq(invoice.getID()))
+            .select(creditNoteEntity.id)
+            .fetchFirst() != null;
+    }
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptEntryImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/persistence/dao/jpa/DAOFRCreditReceiptEntryImpl.java
@@ -63,4 +63,16 @@ public class DAOFRCreditReceiptEntryImpl
                 .select(creditReceiptEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditReceipt(FRReceipt receipt) {
+        QJPAFRCreditReceiptEntity creditReceiptEntity = QJPAFRCreditReceiptEntity.jPAFRCreditReceiptEntity;
+
+        return new JPAQuery<JPAFRCreditReceiptEntity>(this.getEntityManager())
+                .from(creditReceiptEntity)
+                .where(new QJPAFRCreditReceiptEntryEntity(JPAFRCreditReceiptEntryEntity.class, creditReceiptEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .receiptReference.id.eq(receipt.getID()))
+                .select(creditReceiptEntity.id)
+                .fetchFirst() != null;
+    }
 }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRCreditNoteEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRCreditNoteEntryBuilderImpl.java
@@ -82,7 +82,7 @@ public class FRCreditNoteEntryBuilderImpl<TBuilder extends FRCreditNoteEntryBuil
     }
 
     private void ValidateFRCreditNoteEntry(FRCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRCreditReceiptEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRCreditReceiptEntryBuilderImpl.java
@@ -82,7 +82,7 @@ public class FRCreditReceiptEntryBuilderImpl<TBuilder extends FRCreditReceiptEnt
     }
 
     private void ValidateFRCreditReceiptEntry(FRCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditNoteEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditNoteEntryBuilderImpl.java
@@ -94,7 +94,7 @@ public class FRManualCreditNoteEntryBuilderImpl<TBuilder extends FRManualCreditN
     }
 
     private void ValidateFRCreditNoteEntry(FRCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditReceiptEntryBuilderImpl.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/builders/impl/FRManualCreditReceiptEntryBuilderImpl.java
@@ -97,7 +97,7 @@ public class FRManualCreditReceiptEntryBuilderImpl<TBuilder extends FRManualCred
     }
 
     private void ValidateFRCreditReceiptEntry(FRCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditNote.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditNote.java
@@ -42,6 +42,7 @@ public class TestDAOFRCreditNote extends FRPersistencyAbstractTest {
         final DAOFRCreditNoteEntry underTest = this.getInstance(DAOFRCreditNoteEntry.class);
 
         Assertions.assertNull(underTest.checkCreditNote(inv1));
+        Assertions.assertFalse(underTest.existsCreditNote(inv1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOFRCreditNote extends FRPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditNote(inv1));
     }
 }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditReceipt.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/dao/TestDAOFRCreditReceipt.java
@@ -41,6 +41,7 @@ public class TestDAOFRCreditReceipt extends FRPersistencyAbstractTest {
         final DAOFRCreditReceiptEntry underTest = this.getInstance(DAOFRCreditReceiptEntry.class);
 
         Assertions.assertNull(underTest.checkCreditReceipt(rec1));
+        Assertions.assertFalse(underTest.existsCreditReceipt(rec1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOFRCreditReceipt extends FRPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditReceipt(rec1));
     }
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/DAOPTCreditNoteEntry.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/DAOPTCreditNoteEntry.java
@@ -26,4 +26,6 @@ public interface DAOPTCreditNoteEntry extends AbstractDAOPTGenericInvoiceEntry<P
 
     public PTCreditNoteEntity checkCreditNote(PTInvoice invoice);
 
+    public boolean existsCreditNote(PTInvoice invoice);
+
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/jpa/DAOPTCreditNoteEntryImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/persistence/dao/jpa/DAOPTCreditNoteEntryImpl.java
@@ -64,4 +64,17 @@ public class DAOPTCreditNoteEntryImpl
                 .select(creditNoteEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditNote(PTInvoice invoice) {
+
+        QJPAPTCreditNoteEntity creditNoteEntity = QJPAPTCreditNoteEntity.jPAPTCreditNoteEntity;
+
+        return new JPAQuery<JPAPTCreditNoteEntity>(this.getEntityManager())
+            .from(creditNoteEntity)
+            .where(new QJPAPTCreditNoteEntryEntity(JPAPTCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                       .reference.id.eq(invoice.getID()))
+            .select(creditNoteEntity.id)
+            .fetchFirst() != null;
+    }
 }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTCreditNoteEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTCreditNoteEntryBuilderImpl.java
@@ -83,7 +83,7 @@ public class PTCreditNoteEntryBuilderImpl<TBuilder extends PTCreditNoteEntryBuil
     }
 
     private void ValidatePTCreditNoteEntry(PTCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualCreditNoteEntryBuilderImpl.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/builders/impl/PTManualCreditNoteEntryBuilderImpl.java
@@ -95,7 +95,7 @@ public class PTManualCreditNoteEntryBuilderImpl<TBuilder extends PTManualCreditN
     }
 
     private void ValidatePTCreditNoteEntry(PTCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTCreditNote.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/dao/TestDAOPTCreditNote.java
@@ -42,6 +42,7 @@ public class TestDAOPTCreditNote extends PTPersistencyAbstractTest {
         final DAOPTCreditNoteEntry underTest = this.getInstance(DAOPTCreditNoteEntry.class);
 
         Assertions.assertNull(underTest.checkCreditNote(inv1));
+        Assertions.assertFalse(underTest.existsCreditNote(inv1));
     }
 
     @Test
@@ -59,6 +60,7 @@ public class TestDAOPTCreditNote extends PTPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditNote(inv1));
     }
 
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESCreditNoteEntry.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESCreditNoteEntry.java
@@ -26,4 +26,6 @@ public interface DAOESCreditNoteEntry extends AbstractDAOESGenericInvoiceEntry<E
 
     public ESCreditNoteEntity checkCreditNote(ESInvoice invoice);
 
+    public boolean existsCreditNote(ESInvoice invoice);
+
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESCreditReceiptEntry.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/DAOESCreditReceiptEntry.java
@@ -26,4 +26,6 @@ public interface DAOESCreditReceiptEntry extends AbstractDAOESGenericInvoiceEntr
 
     public ESCreditReceiptEntity checkCreditReceipt(ESReceipt invoice);
 
+    public boolean existsCreditReceipt(ESReceipt invoice);
+
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditNoteEntryImpl.java
@@ -63,4 +63,16 @@ public class DAOESCreditNoteEntryImpl
                 .select(creditNoteEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditNote(ESInvoice invoice) {
+        QJPAESCreditNoteEntity creditNoteEntity = QJPAESCreditNoteEntity.jPAESCreditNoteEntity;
+
+        return new JPAQuery<JPAESCreditNoteEntity>(this.getEntityManager())
+            .from(creditNoteEntity)
+            .where(new QJPAESCreditNoteEntryEntity(JPAESCreditNoteEntryEntity.class, creditNoteEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                       .invoiceReference.id.eq(invoice.getID()))
+            .select(creditNoteEntity.id)
+            .fetchFirst() != null;
+    }
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptEntryImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/persistence/dao/jpa/DAOESCreditReceiptEntryImpl.java
@@ -63,4 +63,16 @@ public class DAOESCreditReceiptEntryImpl
                 .select(creditReceiptEntity)
                 .fetchFirst();
     }
+
+    @Override
+    public boolean existsCreditReceipt(ESReceipt receipt) {
+        QJPAESCreditReceiptEntity creditReceiptEntity = QJPAESCreditReceiptEntity.jPAESCreditReceiptEntity;
+
+        return new JPAQuery<JPAESCreditReceiptEntity>(this.getEntityManager())
+                .from(creditReceiptEntity)
+                .where(new QJPAESCreditReceiptEntryEntity(JPAESCreditReceiptEntryEntity.class, creditReceiptEntity.entries.any().getMetadata(), PathInits.DIRECT2)
+                        .receiptReference.id.eq(receipt.getID()))
+                .select(creditReceiptEntity.id)
+                .fetchFirst() != null;
+    }
 }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESCreditNoteEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESCreditNoteEntryBuilderImpl.java
@@ -82,7 +82,7 @@ public class ESCreditNoteEntryBuilderImpl<TBuilder extends ESCreditNoteEntryBuil
     }
 
     private void ValidateESCreditNoteEntry(ESCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESCreditReceiptEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESCreditReceiptEntryBuilderImpl.java
@@ -82,7 +82,7 @@ public class ESCreditReceiptEntryBuilderImpl<TBuilder extends ESCreditReceiptEnt
     }
 
     private void ValidateESCreditReceiptEntry(ESCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualCreditNoteEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualCreditNoteEntryBuilderImpl.java
@@ -95,7 +95,7 @@ public class ESManualCreditNoteEntryBuilderImpl<TBuilder extends ESManualCreditN
     }
 
     private void ValidateESCreditNoteEntry(ESCreditNoteEntryEntity cn) {
-        if (this.daoEntry.checkCreditNote(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditNote(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualCreditReceiptEntryBuilderImpl.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/builders/impl/ESManualCreditReceiptEntryBuilderImpl.java
@@ -95,7 +95,7 @@ public class ESManualCreditReceiptEntryBuilderImpl<TBuilder extends ESManualCred
     }
 
     private void ValidateESCreditReceiptEntry(ESCreditReceiptEntryEntity cn) {
-        if (this.daoEntry.checkCreditReceipt(cn.getReference()) != null) {
+        if (this.daoEntry.existsCreditReceipt(cn.getReference())) {
             throw new DuplicateCreditNoteException();
         }
     }

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditNote.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditNote.java
@@ -42,6 +42,7 @@ public class TestDAOESCreditNote extends ESPersistencyAbstractTest {
         final DAOESCreditNoteEntry underTest = this.getInstance(DAOESCreditNoteEntry.class);
 
         Assertions.assertNull(underTest.checkCreditNote(inv1));
+        Assertions.assertFalse(underTest.existsCreditNote(inv1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOESCreditNote extends ESPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditNote(inv1));
     }
 }

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditReceipt.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/dao/TestDAOESCreditReceipt.java
@@ -41,6 +41,7 @@ public class TestDAOESCreditReceipt extends ESPersistencyAbstractTest {
         final DAOESCreditReceiptEntry underTest = this.getInstance(DAOESCreditReceiptEntry.class);
 
         Assertions.assertNull(underTest.checkCreditReceipt(rec1));
+        Assertions.assertFalse(underTest.existsCreditReceipt(rec1));
     }
 
     @Test
@@ -59,5 +60,6 @@ public class TestDAOESCreditReceipt extends ESPersistencyAbstractTest {
                 .stream()
                 .map(x -> x.getReference().getUID())
                 .collect(MoreCollectors.onlyElement()));
+        Assertions.assertTrue(underTest.existsCreditReceipt(rec1));
     }
 }


### PR DESCRIPTION
This new method performs better, without needing to fetch a lot of data from disk in Postgresql.

There is an open question for Portugal, where this method does not exist, if it should exist or if the method should not exist for all countries.

fixes #425 