### PR TITLE
Add support for series registration by webservices to Portuguese AT (ATCUD)

### DIFF
--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -302,6 +302,20 @@
 							<sourceDestDir>src-generated/main/java</sourceDestDir>
 						</configuration>
 					</execution>
+					<execution>
+						<id>series</id>
+						<goals>
+							<goal>wsimport</goal>
+						</goals>
+						<configuration>
+							<wsdlDirectory>${project.basedir}/src/main/resources/</wsdlDirectory>
+							<wsdlFiles>
+								<wsdlFile>Comunicacao_Series.wsdl</wsdlFile>
+							</wsdlFiles>
+							<packageName>com.premiumminds.billy.portugal.webservices.series</packageName>
+							<sourceDestDir>src-generated/main/java</sourceDestDir>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/AuthenticationHandler.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/AuthenticationHandler.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Set;
+import java.util.TimeZone;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.KeyGenerator;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.namespace.QName;
+import javax.xml.soap.SOAPElement;
+import javax.xml.soap.SOAPEnvelope;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPFactory;
+import javax.xml.soap.SOAPHeader;
+import javax.xml.ws.handler.MessageContext;
+import javax.xml.ws.handler.soap.SOAPHandler;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+
+class AuthenticationHandler implements SOAPHandler<SOAPMessageContext>  {
+
+    private static final String AUTH_NS = "http://schemas.xmlsoap.org/ws/2002/12/secext";
+    private static final String AUTH_PREFIX = "wss";
+    private static final SimpleDateFormat TIMESTAMP_FORMATER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.S'Z'");
+    static {
+        TIMESTAMP_FORMATER.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    private final WebserviceCredentials webserviceCredentials;
+    private final WebserviceKeys webserviceKeys;
+
+    public AuthenticationHandler(WebserviceCredentials webserviceCredentials, WebserviceKeys webserviceKeys) {
+        this.webserviceCredentials = webserviceCredentials;
+        this.webserviceKeys = webserviceKeys;
+    }
+
+    @Override
+    public Set<QName> getHeaders() {
+        return null;
+    }
+
+    @Override
+    public boolean handleMessage(final SOAPMessageContext smc) {
+        boolean direction = (Boolean) smc.get(SOAPMessageContext.MESSAGE_OUTBOUND_PROPERTY);
+
+        if (direction){
+            try {
+                final byte[] simetricKey = generateRequestKey();
+
+                final byte[] encryptedPassword = cypherCredential(simetricKey, webserviceCredentials.getPassword());
+                final String b64EncryptedPassword = Base64.getEncoder().encodeToString(encryptedPassword);
+
+                final String timestamp = getTimestamp();
+                final byte[] encryptedTimestamp = cypherCredential(simetricKey, timestamp);
+                final String b64EncryptedTimestamp = Base64.getEncoder().encodeToString(encryptedTimestamp);
+
+                final Key publicKey = getPublicKeyFromKeystore();
+                final byte[] encriptedSimetricKey = cypherRequestKey((PublicKey) publicKey, simetricKey);
+                final String b64EncryptedSimetricKey = Base64.getEncoder().encodeToString(encriptedSimetricKey);
+
+                createSoapSecurityHeader(smc, b64EncryptedPassword, b64EncryptedTimestamp, b64EncryptedSimetricKey,
+                        webserviceCredentials.getUsername());
+
+            } catch (Exception e){
+                e.printStackTrace();
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean handleFault(final SOAPMessageContext context) {
+        return false;
+    }
+
+    @Override
+    public void close(final MessageContext context) {
+
+    }
+
+    private void createSoapSecurityHeader(SOAPMessageContext smc, String b64EncryptedPassword,
+            String b64EncryptedTimestamp, String b64EncryptedSimetricKey, String username) throws SOAPException {
+        SOAPEnvelope envelope = smc.getMessage().getSOAPPart().getEnvelope();
+        SOAPFactory soapFactory = SOAPFactory.newInstance();
+
+        SOAPElement wsSecHeaderElm = soapFactory.createElement("Security", AUTH_PREFIX, AUTH_NS);
+        SOAPElement userNameTokenElm = soapFactory.createElement("UsernameToken", AUTH_PREFIX, AUTH_NS);
+        SOAPElement userNameElm = soapFactory.createElement("Username", AUTH_PREFIX, AUTH_NS);
+        userNameElm.addTextNode(username);
+        SOAPElement passwdElm = soapFactory.createElement("Password", AUTH_PREFIX, AUTH_NS);
+        passwdElm.addTextNode(b64EncryptedPassword);
+        SOAPElement nonceElm = soapFactory.createElement("Nonce", AUTH_PREFIX, AUTH_NS);
+        nonceElm.addTextNode(b64EncryptedSimetricKey);
+        SOAPElement createdElm = soapFactory.createElement("Created", AUTH_PREFIX, AUTH_NS);
+        createdElm.addTextNode(b64EncryptedTimestamp);
+
+        userNameTokenElm.addChildElement(userNameElm);
+        userNameTokenElm.addChildElement(passwdElm);
+        userNameTokenElm.addChildElement(nonceElm);
+        userNameTokenElm.addChildElement(createdElm);
+
+        wsSecHeaderElm.addChildElement(userNameTokenElm);
+
+        final SOAPHeader sh = envelope.getHeader();
+
+        sh.addChildElement(wsSecHeaderElm);
+    }
+
+    private byte[] cypherRequestKey(PublicKey publicKey, byte[] requestKey)
+            throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException,
+            BadPaddingException {
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+        return cipher.doFinal(requestKey);
+    }
+
+    public byte[] generateRequestKey() throws NoSuchAlgorithmException {
+        KeyGenerator generator = KeyGenerator.getInstance("AES");
+        generator.init(128);
+
+        Key keyToBeWrapped = generator.generateKey();
+
+        return keyToBeWrapped.getEncoded();
+    }
+
+    private byte[] cypherCredential(byte[] requestKey, String credential)
+            throws NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException, IllegalBlockSizeException,
+            BadPaddingException {
+        Cipher cipher = Cipher.getInstance("AES/ECB/PKCS5Padding");
+
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(requestKey, "AES"));
+
+        return cipher.doFinal(credential.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Key getPublicKeyFromKeystore()
+            throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
+
+        KeyStore ks = KeyStore.getInstance("JKS");
+
+        try (InputStream fis = webserviceKeys.getKeystore().toURL().openStream()) {
+            ks.load(fis, webserviceKeys.getKeystorePassword().toCharArray());
+            return ks.getCertificate(webserviceKeys.getKeyAlias()).getPublicKey();
+        }
+    }
+
+    private static String getTimestamp() {
+        Calendar c = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        return TIMESTAMP_FORMATER.format(c.getTime());
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/Client.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/Client.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import com.premiumminds.billy.portugal.webservices.series.ConsultSeriesResp;
+import com.premiumminds.billy.portugal.webservices.series.OperationResultInfo;
+import com.premiumminds.billy.portugal.webservices.series.SeriesResp;
+import com.premiumminds.billy.portugal.webservices.series.SeriesWS;
+import com.premiumminds.billy.portugal.webservices.series.SeriesWSService;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.ws.BindingProvider;
+import javax.xml.ws.handler.Handler;
+
+public class Client {
+
+    private static final int CREATE_SUCCESS_CODE = 2001;
+    private static final int CONSULT_SUCCESS_CODE = 2002;
+    private static final int REVOKE_SUCCESS_CODE = 2003;
+    private static final int FINALIZE_SUCCESS_CODE = 2004;
+    private final URL url;
+    private final WebserviceCredentials webserviceCredentials;
+    private final WebserviceKeys webserviceKeys;
+    private final SslClientCertificate sslClientCertificate;
+
+    public Client(
+        final URL url,
+        final WebserviceCredentials webserviceCredentials,
+        final WebserviceKeys webserviceKeys,
+        final SslClientCertificate sslClientCertificate)
+    {
+        this.url = url;
+        this.webserviceCredentials = webserviceCredentials;
+        this.webserviceKeys = webserviceKeys;
+        this.sslClientCertificate = sslClientCertificate;
+    }
+
+    public SingleSeriesResponse createSeries(CreateSeriesRequest request){
+
+        final SeriesWS seriesWS = getSerieswsPortSoap();
+        final SeriesResp response = seriesWS.registarSerie(
+            request.getSerie(),
+            convert(request.getTipoSerie()),
+            convert(request.getClasseDoc()),
+            convert(request.getTipoDoc()),
+            request.getNumInicialSeq(),
+            convertToXMLGregorianCalendar(request.getDataInicioPrevUtiliz()),
+            new BigInteger(request.getNumCertSWFatur()),
+            convert(request.getMeioProcessamento()));
+
+        return new SingleSeriesResponse(
+            convert(response.getInfoResultOper(), CREATE_SUCCESS_CODE),
+            convert(response.getInfoSerie())
+        );
+    }
+
+    public SingleSeriesResponse finalizeSeries(FinalizeSeriesRequest request){
+
+        final SeriesWS seriesWS = getSerieswsPortSoap();
+        final SeriesResp response = seriesWS.finalizarSerie(
+            request.getSerie(),
+            convert(request.getClasseDoc()),
+            convert(request.getTipoDoc()),
+            request.getCodValidacaoSerie(),
+            request.getSeqUltimoDocEmitido(),
+            request.getJustificacao());
+
+        return new SingleSeriesResponse(
+            convert(response.getInfoResultOper(), FINALIZE_SUCCESS_CODE),
+            convert(response.getInfoSerie())
+        );
+    }
+
+    public SingleSeriesResponse revokeSeries(RevokeSeriesRequest request){
+
+        final SeriesWS seriesWS = getSerieswsPortSoap();
+        final SeriesResp response = seriesWS.anularSerie(
+            request.getSerie(),
+            convert(request.getClasseDoc()),
+            convert(request.getTipoDoc()),
+            request.getCodValidacaoSerie(),
+            convert(request.getMotivo()),
+            request.isDeclaracaoNaoEmissao());
+
+        return new SingleSeriesResponse(
+            convert(response.getInfoResultOper(), REVOKE_SUCCESS_CODE),
+            convert(response.getInfoSerie())
+        );
+    }
+
+    public MultipleSeriesResponse consultSeries(ConsultSeriesRequest request){
+
+        final SeriesWS seriesWS = getSerieswsPortSoap();
+        final ConsultSeriesResp response = seriesWS.consultarSeries(
+            request.getSerie(),
+            convert(request.getTipoSerie()),
+            convert(request.getClasseDoc()),
+            convert(request.getTipoDoc()),
+            request.getCodValidacaoSerie(),
+            convertToXMLGregorianCalendar(request.getDataRegistoDe()),
+            convertToXMLGregorianCalendar(request.getDataRegistoAte()),
+            request.getEstado(),
+            convert(request.getMeioProcessamento()));
+
+        return new MultipleSeriesResponse(
+            convert(response.getInfoResultOper(), CONSULT_SUCCESS_CODE),
+            response.getInfoSerie().stream().map(this::convert).collect(Collectors.toList()));
+    }
+
+    private String convert(RevokeJustification revokeJustification){
+        if (revokeJustification != null){
+            switch (revokeJustification){
+                case REGISTRATION_ERROR: return "ER";
+                default:
+                    throw new RuntimeException("unknown justification: " + revokeJustification);
+            }
+        }
+        return null;
+    }
+
+    private String convert(DocumentType documentType){
+        if (documentType != null){
+            switch (documentType){
+                case INVOICE: return "FT";
+                case SIMPLE_INVOICE: return "FS";
+                case INVOICE_RECEIPT: return "FR";
+                case DEBIT_NOTE: return "ND";
+                case CREDIT_NOTE: return "NC";
+                default:
+                    throw new RuntimeException("unknown document type: " + documentType);
+            }
+        }
+        return null;
+    }
+
+    private String convert(DocumentClass documentClass){
+        if (documentClass != null){
+            switch (documentClass){
+                case INVOICING_DOCUMENTS: return "SI";
+                case TRANSPORT_DOCUMENTS: return "MG";
+                case CONFERENCE_DOCUMENTS: return "WD";
+                case RECEIPTS: return "PY";
+                default:
+                    throw new RuntimeException("unknown document class: " + documentClass);
+            }
+        }
+        return null;
+    }
+    private String convert(SeriesType seriesType){
+        if (seriesType != null){
+            switch (seriesType){
+                case NORMAL: return "N";
+                case RECOVERY: return "F";
+                case TRAINING: return "R";
+                default:
+                    throw new RuntimeException("unknown series type: " + seriesType);
+            }
+        }
+        return null;
+    }
+
+    private String convert(SeriesProcessingMedium processingMedium){
+        if (processingMedium != null){
+            switch (processingMedium){
+                case COMPUTER_PROGRAM: return "PI";
+                case FINANCAS_WEBPORTAL: return "PF";
+                case OTHER_ELECTRONIC: return "OM";
+                default:
+                    throw new RuntimeException("unknown processing medium: " + processingMedium);
+            }
+        }
+        return null;
+    }
+
+    private ResultInfo convert(OperationResultInfo resultInfo, int successCode) {
+        if (resultInfo != null) {
+            return new ResultInfo(
+                resultInfo.getCodResultOper().intValue(),
+                resultInfo.getMsgResultOper(),
+                resultInfo.getCodResultOper().intValue() == successCode);
+        }
+        return null;
+    }
+
+    private SeriesInfo convert(com.premiumminds.billy.portugal.webservices.series.SeriesInfo seriesInfos){
+        if (seriesInfos != null){
+            final SeriesInfo rvalue = new SeriesInfo();
+            rvalue.setSerie(seriesInfos.getSerie());
+            rvalue.setTipoSerie(seriesInfos.getTipoSerie());
+            rvalue.setClasseDoc(seriesInfos.getClasseDoc());
+            rvalue.setTipoDoc(seriesInfos.getTipoDoc());
+            rvalue.setNumInicialSeq(seriesInfos.getNumInicialSeq());
+            rvalue.setNumFinalSeq(seriesInfos.getNumFinalSeq());
+            rvalue.setDataInicioPrevUtiliz(convertLocalDate(seriesInfos.getDataInicioPrevUtiliz()));
+            rvalue.setSeqUltimoDocEmitido(seriesInfos.getSeqUltimoDocEmitido());
+            rvalue.setMeioProcessamento(seriesInfos.getMeioProcessamento());
+            rvalue.setNumCertSWFatur(seriesInfos.getNumCertSWFatur());
+            rvalue.setCodValidacaoSerie(seriesInfos.getCodValidacaoSerie());
+            rvalue.setDataRegisto(convertLocalDate(seriesInfos.getDataRegisto()));
+            rvalue.setEstado(seriesInfos.getEstado());
+            rvalue.setMotivoEstado(seriesInfos.getMotivoEstado());
+            rvalue.setJustificacao(seriesInfos.getJustificacao());
+            rvalue.setDataEstado(convertLocalDateTime(seriesInfos.getDataEstado()));
+            rvalue.setNifComunicou(seriesInfos.getNifComunicou());
+            return rvalue;
+        }
+        return null;
+    }
+
+    private LocalDateTime convertLocalDateTime(XMLGregorianCalendar date) {
+        if (date != null) {
+            return date.toGregorianCalendar().toZonedDateTime().toLocalDateTime();
+        }
+        return null;
+    }
+
+    private LocalDate convertLocalDate(XMLGregorianCalendar date) {
+        if (date != null) {
+            return date.toGregorianCalendar().toZonedDateTime().toLocalDate();
+        }
+        return null;
+    }
+
+    private XMLGregorianCalendar convertToXMLGregorianCalendar(final LocalDate date) {
+        if (date != null){
+            try {
+                return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+                        date.toString());
+            } catch (DatatypeConfigurationException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
+    private SeriesWS getSerieswsPortSoap(){
+
+        final SeriesWSService seriesWSService = new SeriesWSService();
+        final SeriesWS seriesWSPort = seriesWSService.getSeriesWSPort();
+        final BindingProvider bindingProvider = (BindingProvider) seriesWSPort;
+        bindingProvider.getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, url.toString());
+        final List<Handler> chain = bindingProvider.getBinding().getHandlerChain();
+
+        AuthenticationHandler
+            soapClientHeaderHandler = new AuthenticationHandler(webserviceCredentials, webserviceKeys);
+        chain.add(soapClientHeaderHandler);
+        bindingProvider.getBinding().setHandlerChain(chain);
+
+        try {
+            bindingProvider.getRequestContext().put(
+                "com.sun.xml.ws.transport.https.client.SSLSocketFactory",
+                getSslContext(sslClientCertificate).getSocketFactory());
+        } catch (KeyStoreException | IOException | NoSuchAlgorithmException | CertificateException |
+                 UnrecoverableKeyException | KeyManagementException e) {
+            throw new RuntimeException(e);
+        }
+        return seriesWSPort;
+    }
+
+    private SSLContext getSslContext(SslClientCertificate sslClientCertificate)
+        throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException,
+               UnrecoverableKeyException, KeyManagementException
+    {
+        try (InputStream keyStoreInputStream = sslClientCertificate.getPath().toURL().openStream()) {
+
+            final KeyStore keyStore= KeyStore.getInstance("pkcs12");
+            keyStore.load(keyStoreInputStream, sslClientCertificate.getPassword().toCharArray());
+
+            final KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+            kmf.init(keyStore, sslClientCertificate.getPassword().toCharArray());
+
+            final SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(kmf.getKeyManagers(), null, null);
+
+            return sslContext;
+        }
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/ConsultSeriesRequest.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/ConsultSeriesRequest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.time.LocalDate;
+
+public class ConsultSeriesRequest {
+
+    private String serie;
+    private SeriesType tipoSerie;
+    private DocumentClass classeDoc;
+    private DocumentType tipoDoc;
+    private String codValidacaoSerie;
+    private LocalDate dataRegistoDe;
+    private LocalDate dataRegistoAte;
+    private String estado;
+    private SeriesProcessingMedium meioProcessamento;
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        this.serie = serie;
+    }
+
+    public SeriesType getTipoSerie() {
+        return tipoSerie;
+    }
+
+    public void setTipoSerie(final SeriesType tipoSerie) {
+        this.tipoSerie = tipoSerie;
+    }
+
+    public DocumentClass getClasseDoc() {
+        return classeDoc;
+    }
+
+    public void setClasseDoc(final DocumentClass classeDoc) {
+        this.classeDoc = classeDoc;
+    }
+
+    public DocumentType getTipoDoc() {
+        return tipoDoc;
+    }
+
+    public void setTipoDoc(final DocumentType tipoDoc) {
+        this.tipoDoc = tipoDoc;
+    }
+
+    public String getCodValidacaoSerie() {
+        return codValidacaoSerie;
+    }
+
+    public void setCodValidacaoSerie(final String codValidacaoSerie) {
+        this.codValidacaoSerie = codValidacaoSerie;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public void setEstado(final String estado) {
+        this.estado = estado;
+    }
+
+    public SeriesProcessingMedium getMeioProcessamento() {
+        return meioProcessamento;
+    }
+
+    public void setMeioProcessamento(final SeriesProcessingMedium meioProcessamento) {
+        this.meioProcessamento = meioProcessamento;
+    }
+
+    public LocalDate getDataRegistoDe() {
+        return dataRegistoDe;
+    }
+
+    public void setDataRegistoDe(final LocalDate dataRegistoDe) {
+        this.dataRegistoDe = dataRegistoDe;
+    }
+
+    public LocalDate getDataRegistoAte() {
+        return dataRegistoAte;
+    }
+
+    public void setDataRegistoAte(final LocalDate dataRegistoAte) {
+        this.dataRegistoAte = dataRegistoAte;
+    }
+
+    @Override
+    public String toString() {
+        return "ConsultSeriesRequest{" + "serie='" + serie + '\'' + ", tipoSerie='" + tipoSerie + '\'' +
+            ", classeDoc='" + classeDoc + '\'' + ", tipoDoc='" + tipoDoc + '\'' + ", codValidacaoSerie='" +
+            codValidacaoSerie + '\'' + ", dataRegistoDe=" + dataRegistoDe + ", dataRegistoAte=" + dataRegistoAte +
+            ", estado='" + estado + '\'' + ", meioProcessamento='" + meioProcessamento + '\'' + '}';
+    }
+
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/CreateSeriesRequest.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/CreateSeriesRequest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+public class CreateSeriesRequest {
+
+    private String serie;
+    private SeriesType tipoSerie;
+    private DocumentClass classeDoc;
+    private DocumentType tipoDoc;
+    private BigInteger numInicialSeq;
+    private LocalDate dataInicioPrevUtiliz;
+    private String numCertSWFatur;
+    private SeriesProcessingMedium meioProcessamento;
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        this.serie = serie;
+    }
+
+    public SeriesType getTipoSerie() {
+        return tipoSerie;
+    }
+
+    public void setTipoSerie(final SeriesType tipoSerie) {
+        this.tipoSerie = tipoSerie;
+    }
+
+    public DocumentClass getClasseDoc() {
+        return classeDoc;
+    }
+
+    public void setClasseDoc(final DocumentClass classeDoc) {
+        this.classeDoc = classeDoc;
+    }
+
+    public DocumentType getTipoDoc() {
+        return tipoDoc;
+    }
+
+    public void setTipoDoc(final DocumentType tipoDoc) {
+        this.tipoDoc = tipoDoc;
+    }
+
+    public BigInteger getNumInicialSeq() {
+        return numInicialSeq;
+    }
+
+    public void setNumInicialSeq(final BigInteger numInicialSeq) {
+        this.numInicialSeq = numInicialSeq;
+    }
+
+    public LocalDate getDataInicioPrevUtiliz() {
+        return dataInicioPrevUtiliz;
+    }
+
+    public void setDataInicioPrevUtiliz(final LocalDate dataInicioPrevUtiliz) {
+        this.dataInicioPrevUtiliz = dataInicioPrevUtiliz;
+    }
+
+    public String getNumCertSWFatur() {
+        return numCertSWFatur;
+    }
+
+    public void setNumCertSWFatur(final String numCertSWFatur) {
+        this.numCertSWFatur = numCertSWFatur;
+    }
+
+    public SeriesProcessingMedium getMeioProcessamento() {
+        return meioProcessamento;
+    }
+
+    public void setMeioProcessamento(final SeriesProcessingMedium meioProcessamento) {
+        this.meioProcessamento = meioProcessamento;
+    }
+
+    @Override
+    public String toString() {
+        return "CreateSeriesRequest{" + "serie='" + serie + '\'' + ", tipoSerie='" + tipoSerie + '\'' +
+            ", classeDoc='" + classeDoc + '\'' + ", tipoDoc='" + tipoDoc + '\'' + ", numInicialSeq=" + numInicialSeq +
+            ", dataInicioPrevUtiliz=" + dataInicioPrevUtiliz + ", numCertSWFatur='" + numCertSWFatur + '\'' +
+            ", meioProcessamento='" + meioProcessamento + '\'' + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/DocumentClass.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/DocumentClass.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum DocumentClass {
+
+    INVOICING_DOCUMENTS,
+    TRANSPORT_DOCUMENTS,
+    CONFERENCE_DOCUMENTS,
+    RECEIPTS,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/DocumentType.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/DocumentType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum DocumentType {
+
+    INVOICE,
+    SIMPLE_INVOICE,
+    INVOICE_RECEIPT,
+    DEBIT_NOTE,
+    CREDIT_NOTE,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/FinalizeSeriesRequest.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/FinalizeSeriesRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+
+public class FinalizeSeriesRequest {
+
+    private String serie;
+    private DocumentClass classeDoc;
+    private DocumentType tipoDoc;
+    private String codValidacaoSerie;
+    private BigInteger seqUltimoDocEmitido;
+    private String justificacao;
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        this.serie = serie;
+    }
+
+    public DocumentClass getClasseDoc() {
+        return classeDoc;
+    }
+
+    public void setClasseDoc(final DocumentClass classeDoc) {
+        this.classeDoc = classeDoc;
+    }
+
+    public DocumentType getTipoDoc() {
+        return tipoDoc;
+    }
+
+    public void setTipoDoc(final DocumentType tipoDoc) {
+        this.tipoDoc = tipoDoc;
+    }
+
+    public String getCodValidacaoSerie() {
+        return codValidacaoSerie;
+    }
+
+    public void setCodValidacaoSerie(final String codValidacaoSerie) {
+        this.codValidacaoSerie = codValidacaoSerie;
+    }
+
+    public BigInteger getSeqUltimoDocEmitido() {
+        return seqUltimoDocEmitido;
+    }
+
+    public void setSeqUltimoDocEmitido(final BigInteger seqUltimoDocEmitido) {
+        this.seqUltimoDocEmitido = seqUltimoDocEmitido;
+    }
+
+    public String getJustificacao() {
+        return justificacao;
+    }
+
+    public void setJustificacao(final String justificacao) {
+        this.justificacao = justificacao;
+    }
+
+    @Override
+    public String toString() {
+        return "FinalizeSeriesRequest{" + "serie='" + serie + '\'' + ", classeDoc=" + classeDoc + ", tipoDoc=" +
+            tipoDoc + ", codValidacaoSerie='" + codValidacaoSerie + '\'' + ", seqUltimoDocEmitido=" +
+            seqUltimoDocEmitido + ", justificacao='" + justificacao + '\'' + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/MultipleSeriesResponse.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/MultipleSeriesResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class MultipleSeriesResponse {
+
+    private final ResultInfo resultInfo;
+    private final List<SeriesInfo> infoSerie = new ArrayList<>();
+
+    public MultipleSeriesResponse(final ResultInfo resultInfo, List<SeriesInfo> infoSerie) {
+        this.resultInfo = resultInfo;
+        this.infoSerie.addAll(infoSerie);
+    }
+
+    public ResultInfo getResultInfo() {
+        return resultInfo;
+    }
+
+    public List<SeriesInfo> getInfoSerie() {
+        return Collections.unmodifiableList(infoSerie);
+    }
+
+    @Override
+    public String toString() {
+        return "MultipleSeriesResponse{" + "resultInfo=" + resultInfo + ", infoSerie=" + infoSerie + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/ResultInfo.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/ResultInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public class ResultInfo {
+
+    private final int code;
+    private final String message;
+    private final boolean success;
+
+    public ResultInfo(final int code, final String message, final boolean success) {
+        this.code = code;
+        this.message = message;
+        this.success = success;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    @Override
+    public String toString() {
+        return "ResultInfo{" + "code=" + code + ", message='" + message + '\'' + ", success=" + success + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/RevokeJustification.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/RevokeJustification.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum RevokeJustification {
+
+    REGISTRATION_ERROR,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/RevokeSeriesRequest.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/RevokeSeriesRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public class RevokeSeriesRequest {
+
+    private String serie;
+    private DocumentClass classeDoc;
+    private DocumentType tipoDoc;
+    private String codValidacaoSerie;
+    private RevokeJustification motivo;
+    private boolean declaracaoNaoEmissao;
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        this.serie = serie;
+    }
+
+    public DocumentClass getClasseDoc() {
+        return classeDoc;
+    }
+
+    public void setClasseDoc(final DocumentClass classeDoc) {
+        this.classeDoc = classeDoc;
+    }
+
+    public DocumentType getTipoDoc() {
+        return tipoDoc;
+    }
+
+    public void setTipoDoc(final DocumentType tipoDoc) {
+        this.tipoDoc = tipoDoc;
+    }
+
+    public String getCodValidacaoSerie() {
+        return codValidacaoSerie;
+    }
+
+    public void setCodValidacaoSerie(final String codValidacaoSerie) {
+        this.codValidacaoSerie = codValidacaoSerie;
+    }
+
+    public RevokeJustification getMotivo() {
+        return motivo;
+    }
+
+    public void setMotivo(final RevokeJustification motivo) {
+        this.motivo = motivo;
+    }
+
+    public boolean isDeclaracaoNaoEmissao() {
+        return declaracaoNaoEmissao;
+    }
+
+    public void setDeclaracaoNaoEmissao(final boolean declaracaoNaoEmissao) {
+        this.declaracaoNaoEmissao = declaracaoNaoEmissao;
+    }
+
+    @Override
+    public String toString() {
+        return "RevokeSeriesRequest{" + "serie='" + serie + '\'' + ", classeDoc=" + classeDoc + ", tipoDoc=" + tipoDoc +
+            ", codValidacaoSerie='" + codValidacaoSerie + '\'' + ", motivo='" + motivo + '\'' +
+            ", declaracaoNaoEmissao=" + declaracaoNaoEmissao + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesInfo.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesInfo.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class SeriesInfo {
+
+    private String serie;
+    private String tipoSerie;
+    private String classeDoc;
+    private String tipoDoc;
+    private BigInteger numInicialSeq;
+    private BigInteger numFinalSeq;
+    private LocalDate dataInicioPrevUtiliz;
+    private BigInteger seqUltimoDocEmitido;
+    private String meioProcessamento;
+    private BigInteger numCertSWFatur;
+    private String codValidacaoSerie;
+    private LocalDate dataRegisto;
+    private String estado;
+    private String motivoEstado;
+    private String justificacao;
+    private LocalDateTime dataEstado;
+    private String nifComunicou;
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        this.serie = serie;
+    }
+
+    public String getTipoSerie() {
+        return tipoSerie;
+    }
+
+    public void setTipoSerie(final String tipoSerie) {
+        this.tipoSerie = tipoSerie;
+    }
+
+    public String getClasseDoc() {
+        return classeDoc;
+    }
+
+    public void setClasseDoc(final String classeDoc) {
+        this.classeDoc = classeDoc;
+    }
+
+    public String getTipoDoc() {
+        return tipoDoc;
+    }
+
+    public void setTipoDoc(final String tipoDoc) {
+        this.tipoDoc = tipoDoc;
+    }
+
+    public BigInteger getNumInicialSeq() {
+        return numInicialSeq;
+    }
+
+    public void setNumInicialSeq(final BigInteger numInicialSeq) {
+        this.numInicialSeq = numInicialSeq;
+    }
+
+    public BigInteger getNumFinalSeq() {
+        return numFinalSeq;
+    }
+
+    public void setNumFinalSeq(final BigInteger numFinalSeq) {
+        this.numFinalSeq = numFinalSeq;
+    }
+
+    public BigInteger getSeqUltimoDocEmitido() {
+        return seqUltimoDocEmitido;
+    }
+
+    public void setSeqUltimoDocEmitido(final BigInteger seqUltimoDocEmitido) {
+        this.seqUltimoDocEmitido = seqUltimoDocEmitido;
+    }
+
+    public String getMeioProcessamento() {
+        return meioProcessamento;
+    }
+
+    public void setMeioProcessamento(final String meioProcessamento) {
+        this.meioProcessamento = meioProcessamento;
+    }
+
+    public BigInteger getNumCertSWFatur() {
+        return numCertSWFatur;
+    }
+
+    public void setNumCertSWFatur(final BigInteger numCertSWFatur) {
+        this.numCertSWFatur = numCertSWFatur;
+    }
+
+    public String getCodValidacaoSerie() {
+        return codValidacaoSerie;
+    }
+
+    public void setCodValidacaoSerie(final String codValidacaoSerie) {
+        this.codValidacaoSerie = codValidacaoSerie;
+    }
+
+    public String getEstado() {
+        return estado;
+    }
+
+    public void setEstado(final String estado) {
+        this.estado = estado;
+    }
+
+    public String getMotivoEstado() {
+        return motivoEstado;
+    }
+
+    public void setMotivoEstado(final String motivoEstado) {
+        this.motivoEstado = motivoEstado;
+    }
+
+    public String getJustificacao() {
+        return justificacao;
+    }
+
+    public void setJustificacao(final String justificacao) {
+        this.justificacao = justificacao;
+    }
+
+    public String getNifComunicou() {
+        return nifComunicou;
+    }
+
+    public void setNifComunicou(final String nifComunicou) {
+        this.nifComunicou = nifComunicou;
+    }
+
+    public LocalDate getDataInicioPrevUtiliz() {
+        return dataInicioPrevUtiliz;
+    }
+
+    public void setDataInicioPrevUtiliz(final LocalDate dataInicioPrevUtiliz) {
+        this.dataInicioPrevUtiliz = dataInicioPrevUtiliz;
+    }
+
+    public LocalDate getDataRegisto() {
+        return dataRegisto;
+    }
+
+    public void setDataRegisto(final LocalDate dataRegisto) {
+        this.dataRegisto = dataRegisto;
+    }
+
+    public LocalDateTime getDataEstado() {
+        return dataEstado;
+    }
+
+    public void setDataEstado(final LocalDateTime dataEstado) {
+        this.dataEstado = dataEstado;
+    }
+
+    @Override
+    public String toString() {
+        return "SeriesInfo{" + "serie='" + serie + '\'' + ", tipoSerie='" + tipoSerie + '\'' + ", classeDoc='" +
+            classeDoc + '\'' + ", tipoDoc='" + tipoDoc + '\'' + ", numInicialSeq=" + numInicialSeq + ", numFinalSeq=" +
+            numFinalSeq + ", dataInicioPrevUtiliz=" + dataInicioPrevUtiliz + ", seqUltimoDocEmitido=" +
+            seqUltimoDocEmitido + ", meioProcessamento='" + meioProcessamento + '\'' + ", numCertSWFatur=" +
+            numCertSWFatur + ", codValidacaoSerie='" + codValidacaoSerie + '\'' + ", dataRegisto=" + dataRegisto +
+            ", estado='" + estado + '\'' + ", motivoEstado='" + motivoEstado + '\'' + ", justificacao='" +
+            justificacao + '\'' + ", dataEstado=" + dataEstado + ", nifComunicou='" + nifComunicou + '\'' + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesProcessingMedium.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesProcessingMedium.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum SeriesProcessingMedium {
+
+    COMPUTER_PROGRAM,
+    FINANCAS_WEBPORTAL,
+    OTHER_ELECTRONIC,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesState.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesState.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum SeriesState {
+
+    ACTIVE,
+    REVOKED,
+    FINALIZED,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesType.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SeriesType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public enum SeriesType {
+
+    NORMAL,
+    TRAINING,
+    RECOVERY,
+
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SingleSeriesResponse.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SingleSeriesResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public class SingleSeriesResponse {
+
+    private final ResultInfo resultInfo;
+    private final SeriesInfo infoSerie;
+
+    public SingleSeriesResponse(final ResultInfo resultInfo, final SeriesInfo infoSerie) {
+        this.resultInfo = resultInfo;
+        this.infoSerie = infoSerie;
+    }
+
+    public ResultInfo getResultInfo() {
+        return resultInfo;
+    }
+
+    public SeriesInfo getInfoSerie() {
+        return infoSerie;
+    }
+
+    @Override
+    public String toString() {
+        return "SingleSeriesResponse{" + "resultInfo=" + resultInfo + ", infoSerie=" + infoSerie + '}';
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SslClientCertificate.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/SslClientCertificate.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.net.URI;
+
+public class SslClientCertificate {
+
+    private final URI path;
+    private final String password;
+
+    public SslClientCertificate(URI path, String password) {
+        this.path = path;
+        this.password = password;
+    }
+
+    public URI getPath() {
+        return path;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/WebserviceCredentials.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/WebserviceCredentials.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+public class WebserviceCredentials {
+
+    private final String username;
+    private final String password;
+
+    public WebserviceCredentials(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/WebserviceKeys.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/WebserviceKeys.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import java.net.URI;
+
+public class WebserviceKeys {
+
+    private final URI keystore;
+    private final String keystorePassword;
+    private final String keyAlias;
+
+    public WebserviceKeys(URI keystore, String keystorePassword, String keyAlias) {
+        this.keystore = keystore;
+        this.keystorePassword = keystorePassword;
+        this.keyAlias = keyAlias;
+    }
+
+    public URI getKeystore() {
+        return keystore;
+    }
+
+    public String getKeystorePassword() {
+        return keystorePassword;
+    }
+
+    public String getKeyAlias() {
+        return keyAlias;
+    }
+}

--- a/billy-portugal/src/main/resources/Comunicacao_Series.wsdl
+++ b/billy-portugal/src/main/resources/Comunicacao_Series.wsdl
@@ -1,0 +1,529 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2017 Premium Minds.
+
+    This file is part of billy portugal (PT Pack).
+
+    billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free
+    Software Foundation, either version 3 of the License, or (at your option) any
+    later version.
+
+    billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+    WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+    A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+    details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+
+-->
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                  xmlns:wsp="http://www.w3.org/ns/ws-policy"
+                  xmlns="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:wsp1_2="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                  xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:tns="http://at.gov.pt/"
+                  targetNamespace="http://at.gov.pt/"
+                  name="SeriesWSService">
+   <wsdl:types>
+      <xsd:schema xmlns:ns0="http://at.gov.pt/" targetNamespace="http://at.gov.pt/">
+         <xsd:element name="anularSerie" type="ns0:anularSerie"/>
+         <xsd:element name="anularSerieResponse" type="ns0:anularSerieResponse"/>
+         <xsd:element name="consultarSeries" type="ns0:consultarSeries"/>
+         <xsd:element name="consultarSeriesResponse" type="ns0:consultarSeriesResponse"/>
+         <xsd:element name="finalizarSerie" type="ns0:finalizarSerie"/>
+         <xsd:element name="finalizarSerieResponse" type="ns0:finalizarSerieResponse"/>
+         <xsd:element name="registarSerie" type="ns0:registarSerie"/>
+         <xsd:element name="registarSerieResponse" type="ns0:registarSerieResponse"/>
+         <xsd:simpleType name="serieType">
+            <xsd:restriction base="xsd:string">
+               <xsd:maxLength value="35"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="tipoSerieType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="1"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="classeDocType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="2"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="tipoDocType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="2"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="numSeqType">
+            <xsd:restriction base="xsd:integer">
+               <xsd:minInclusive value="1"/>
+               <xsd:totalDigits value="25"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="numCertSWFaturType">
+            <xsd:restriction base="xsd:integer">
+               <xsd:minInclusive value="0"/>
+               <xsd:totalDigits value="4"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="codValidacaoSerieType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="8"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="motivoType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="2"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="justificacaoType">
+            <xsd:restriction base="xsd:string">
+               <xsd:maxLength value="4000"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="estadoType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="1"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="codResultOperType">
+            <xsd:restriction base="xsd:integer">
+               <xsd:totalDigits value="4"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="msgResultOperType">
+            <xsd:restriction base="xsd:string">
+               <xsd:maxLength value="250"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="nifType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="9"/>
+               <xsd:pattern value="\d{9}"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:simpleType name="meioProcessamentoType">
+            <xsd:restriction base="xsd:string">
+               <xsd:length value="2"/>
+            </xsd:restriction>
+         </xsd:simpleType>
+         <xsd:complexType name="anularSerie">
+            <xsd:sequence>
+               <xsd:element name="serie" type="ns0:serieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o identificador da Série cuja comunicação pretende anular.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="classeDoc" type="ns0:classeDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a classificação dada ao documento a que pertence a Série cuja comunicação pretende anular.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoDoc" type="ns0:tipoDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo de documento a que pertence a Série cuja comunicação pretende anular.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="codValidacaoSerie" type="ns0:codValidacaoSerieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o código de validação da série, atribuído pela AT, cuja comunicação pretende anular.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="motivo" type="ns0:motivoType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o motivo pelo qual pretende anular a comunicação da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+			            <xsd:element name="declaracaoNaoEmissao" type="xsd:boolean">
+				              <xsd:annotation>
+                    <xsd:documentation>Indicação informativa de que o sujeito passivo teve conhecimento de que não deve anular a comunicação de uma Série se já utilizou documentos emitidos com a informação da mesma. A comunicação não será aceite se o sujeito passivo não indicar (preenchendo com o valor verdadeiro este parâmetro) que teve conhecimento da condição apresentada.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="anularSerieResponse">
+            <xsd:sequence>
+               <xsd:element name="anularSerieResp" type="ns0:seriesResp"/>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="consultarSeries">
+            <xsd:sequence>
+               <xsd:element name="serie" type="ns0:serieType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o identificador da Série que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoSerie" type="ns0:tipoSerieType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo da Série que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="classeDoc" type="ns0:classeDocType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a classificação dada ao documento a que pertence a Série que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoDoc" type="ns0:tipoDocType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo de documento a que pertence a Série que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="codValidacaoSerie" type="ns0:codValidacaoSerieType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o código de validação da Série, atribuído pela AT, que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataRegistoDe" type="xsd:date" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a data inicial do intervalo de pesquisa.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataRegistoAte" type="xsd:date" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a data final do intervalo de pesquisa.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="estado" type="ns0:estadoType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o estado da Série que pretende consultar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="meioProcessamento" type="ns0:meioProcessamentoType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Código de meio de processamento dos documentos a emitir.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="consultarSeriesResponse">
+            <xsd:sequence>
+               <xsd:element name="consultarSeriesResp" type="ns0:consultSeriesResp"/>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="finalizarSerie">
+            <xsd:sequence>
+               <xsd:element name="serie" type="ns0:serieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o identificador da Série que pretende finalizar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="classeDoc" type="ns0:classeDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a classificação dada ao documento a que pertence a Série que pretende finalizar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoDoc" type="ns0:tipoDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo de documento a que pertence a Série que pretende finalizar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="codValidacaoSerie" type="ns0:codValidacaoSerieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o código de validação da série, atribuído pela AT, que pretende finalizar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="seqUltimoDocEmitido" type="ns0:numSeqType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o número do último documento emitido da Série que pretende finalizar.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+			            <xsd:element name="justificacao" type="ns0:justificacaoType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique observações pertinentes à finalização da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="finalizarSerieResponse">
+            <xsd:sequence>
+               <xsd:element name="finalizarSerieResp" type="ns0:seriesResp"/>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="registarSerie">
+            <xsd:sequence>
+               <xsd:element name="serie" type="ns0:serieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o identificador da Série que pretende comunicar a AT.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoSerie" type="ns0:tipoSerieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo da Série que pretende comunicar a AT.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="classeDoc" type="ns0:classeDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a classificação dada ao documento a que pertence a Série a comunicar à AT.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoDoc" type="ns0:tipoDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o tipo de documento a que pertence a Série a comunicar à AT.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="numInicialSeq" type="ns0:numSeqType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o início da numeração de sequência do documento na Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataInicioPrevUtiliz" type="xsd:date">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique a data a partir da qual se prevê a utilização da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="numCertSWFatur" type="ns0:numCertSWFaturType">
+                  <xsd:annotation>
+                    <xsd:documentation>Indique o número do certificado do programa de faturação, atribuído pela AT. Se não aplicável, deve ser preenchido com "0" (zero).</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="meioProcessamento" type="ns0:meioProcessamentoType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código de meio de processamento dos documentos a emitir.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="registarSerieResponse">
+            <xsd:sequence>
+               <xsd:element name="registarSerieResp" type="ns0:seriesResp"/>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="seriesResp">
+            <xsd:sequence>
+               <xsd:element name="infoSerie" type="ns0:seriesInfo" minOccurs="0"/>
+               <xsd:element name="infoResultOper" type="ns0:operationResultInfo"/>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="seriesInfo">
+            <xsd:annotation>
+               <xsd:documentation>Informação de caracterização da Série comunicada</xsd:documentation>
+            </xsd:annotation>
+            <xsd:sequence>
+               <xsd:element name="serie" type="ns0:serieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Identificador da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoSerie" type="ns0:tipoSerieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código do tipo da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="classeDoc" type="ns0:classeDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código da classificação dada ao documento a que pertence a Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="tipoDoc" type="ns0:tipoDocType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código do tipo de documento da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="numInicialSeq" type="ns0:numSeqType">
+                  <xsd:annotation>
+                    <xsd:documentation>Início da numeração de sequência do documento na Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="numFinalSeq" type="ns0:numSeqType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Fim da numeração de sequência do documento na Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataInicioPrevUtiliz" type="xsd:date">
+                  <xsd:annotation>
+                    <xsd:documentation>Data a partir da qual se prevê a utilização da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="seqUltimoDocEmitido" type="ns0:numSeqType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Sequência do último documento emitido da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="meioProcessamento" type="ns0:meioProcessamentoType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código de meio de processamento dos documentos a emitir.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="numCertSWFatur" type="ns0:numCertSWFaturType">
+                  <xsd:annotation>
+                    <xsd:documentation>Número do certificado do programa de faturação, atribuído pela AT. Se não aplicável, o resultado é preenchido com "0" (zero).</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="codValidacaoSerie" type="ns0:codValidacaoSerieType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código de validação da Série, atribuído pela AT.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataRegisto" type="xsd:date">
+                  <xsd:annotation>
+                    <xsd:documentation>Data do registo da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="estado" type="ns0:estadoType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código do estado que a Série possui no decorrer do processo de comunicação.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="motivoEstado" type="ns0:motivoType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Código de motivo justificativo da mudança de estado.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="justificacao" type="ns0:justificacaoType" minOccurs="0">
+                  <xsd:annotation>
+                    <xsd:documentation>Observações pertinentes comunicadas sobre a finalização da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="dataEstado" type="xsd:dateTime">
+                  <xsd:annotation>
+                    <xsd:documentation>Data da última alteração de estado da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="nifComunicou" type="ns0:nifType">
+                  <xsd:annotation>
+                    <xsd:documentation>Número fiscal do contribuinte responsável pela comunicação da Série.</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="operationResultInfo">
+            <xsd:annotation>
+               <xsd:documentation>Resultado da operação</xsd:documentation>
+            </xsd:annotation>
+            <xsd:sequence>
+               <xsd:element name="codResultOper" type="ns0:codResultOperType">
+                  <xsd:annotation>
+                    <xsd:documentation>Código do resultado da operação</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+               <xsd:element name="msgResultOper" type="ns0:msgResultOperType">
+                  <xsd:annotation>
+                    <xsd:documentation>Mensagem do resultado da operação</xsd:documentation>
+                  </xsd:annotation>
+               </xsd:element>
+            </xsd:sequence>
+         </xsd:complexType>
+         <xsd:complexType name="consultSeriesResp">
+            <xsd:sequence>
+               <xsd:element name="infoSerie" type="ns0:seriesInfo" minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="infoResultOper" type="ns0:operationResultInfo"/>
+            </xsd:sequence>
+         </xsd:complexType>
+      </xsd:schema>
+   </wsdl:types>
+   <message name="registarSerie">
+        <part name="parameters" element="tns:registarSerie"/>
+    </message>
+   <message name="registarSerieResponse">
+        <part name="parameters" element="tns:registarSerieResponse"/>
+    </message>
+   <message name="finalizarSerie">
+        <part name="parameters" element="tns:finalizarSerie"/>
+    </message>
+   <message name="finalizarSerieResponse">
+        <part name="parameters" element="tns:finalizarSerieResponse"/>
+    </message>
+   <message name="consultarSeries">
+        <part name="parameters" element="tns:consultarSeries"/>
+    </message>
+   <message name="consultarSeriesResponse">
+        <part name="parameters" element="tns:consultarSeriesResponse"/>
+    </message>
+   <message name="anularSerie">
+        <part name="parameters" element="tns:anularSerie"/>
+    </message>
+   <message name="anularSerieResponse">
+        <part name="parameters" element="tns:anularSerieResponse"/>
+    </message>
+   <portType name="SeriesWS">
+        <operation name="registarSerie">
+            <documentation>
+                Esta funcionalidade tem como objetivo, permitir a comunicação das séries à AT, através do 
+                registo das mesmas, de modo a que seja atribuído um código único de validação da série.
+            </documentation>
+            <input wsam:Action="http://at.gov.pt/SeriesWS/registarSerieRequest"
+                message="tns:registarSerie"/>
+            <output wsam:Action="http://at.gov.pt/SeriesWS/registarSerieResponse"
+                 message="tns:registarSerieResponse"/>
+        </operation>
+        <operation name="finalizarSerie">
+            <documentation>
+                Esta funcionalidade tem como objetivo, indicar que uma série foi válida para um conjunto 
+                de documentos, mas que a mesma já não será usada a partir do último documento comunicado.
+            </documentation>
+            <input wsam:Action="http://at.gov.pt/SeriesWS/finalizarSerieRequest"
+                message="tns:finalizarSerie"/>
+            <output wsam:Action="http://at.gov.pt/SeriesWS/finalizarSerieResponse"
+                 message="tns:finalizarSerieResponse"/>
+        </operation>
+        <operation name="consultarSeries">
+            <documentation>
+                Esta funcionalidade tem como objetivo, disponibilizar a consulta das séries comunicadas.
+            </documentation>
+            <input wsam:Action="http://at.gov.pt/SeriesWS/consultarSeriesRequest"
+                message="tns:consultarSeries"/>
+            <output wsam:Action="http://at.gov.pt/SeriesWS/consultarSeriesResponse"
+                 message="tns:consultarSeriesResponse"/>
+        </operation>
+        <operation name="anularSerie">
+            <documentation>
+                Esta funcionalidade tem como objetivo, disponibilizar a ação de anular a comunicação 
+                de uma série anteriormente comunicada, por erro.
+            </documentation>
+            <input wsam:Action="http://at.gov.pt/SeriesWS/anularSerieRequest"
+                message="tns:anularSerie"/>
+            <output wsam:Action="http://at.gov.pt/SeriesWS/anularSerieResponse"
+                 message="tns:anularSerieResponse"/>
+        </operation>
+    </portType>
+   <binding name="SeriesWSPortBinding" type="tns:SeriesWS">
+        <soap:binding transport="http://schemas.xmlsoap.org/soap/http" style="document"/>
+        <operation name="registarSerie">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="finalizarSerie">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="consultarSeries">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+        <operation name="anularSerie">
+            <soap:operation soapAction=""/>
+            <input>
+                <soap:body use="literal"/>
+            </input>
+            <output>
+                <soap:body use="literal"/>
+            </output>
+        </operation>
+    </binding>
+   <service name="SeriesWSService">
+        <port name="SeriesWSPort" binding="tns:SeriesWSPortBinding">
+            <soap:address location="http://localhost:7001/seriesbo/SeriesWSService"/>
+        </port>
+    </service>
+</wsdl:definitions>

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/services/series/webservice/ClientTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/services/series/webservice/ClientTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import com.premiumminds.billy.portugal.webservices.series.ConsultSeriesResp;
+import com.premiumminds.billy.portugal.webservices.series.OperationResultInfo;
+import com.premiumminds.billy.portugal.webservices.series.SeriesInfo;
+import com.premiumminds.billy.portugal.webservices.series.SeriesResp;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.time.LocalDate;
+import java.util.Objects;
+import javax.xml.ws.Endpoint;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ClientTest {
+
+    private StubSeriesWS webService;
+    private URL stubServerUrl;
+    private Endpoint publish;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        stubServerUrl = new URL("http", "localhost", getFreePort(), "/dummy");
+        final String bindingURI = stubServerUrl.toString();
+
+        webService = new StubSeriesWS();
+
+        publish = Endpoint.publish(bindingURI, webService);
+    }
+
+    @AfterEach
+    void tearDown(){
+        publish.stop();
+    }
+
+
+    @Test
+    void createSeries() throws Exception {
+
+        webService.setRegistarSerieCallback(serie -> {
+            final SeriesResp seriesResp = new SeriesResp();
+            final OperationResultInfo infoResultOper = new OperationResultInfo();
+            infoResultOper.setCodResultOper(BigInteger.valueOf(2001));
+            infoResultOper.setMsgResultOper("success");
+            seriesResp.setInfoResultOper(infoResultOper);
+            final SeriesInfo info = new SeriesInfo();
+            info.setSerie(serie);
+            info.setCodValidacaoSerie("AAJFFSPSWJ");
+            seriesResp.setInfoSerie(info);
+            return seriesResp;
+        });
+
+        WebserviceCredentials
+            webserviceCredentials = new WebserviceCredentials("599999993/37", "testes1234");
+        WebserviceKeys webserviceKeys =
+            new WebserviceKeys(Objects.requireNonNull(getClass().getResource("/saPubKey.jks")).toURI(), "saKeyPubPass", "sapubkey.prod");
+
+        SslClientCertificate sslClientCertificate =
+            new SslClientCertificate(Objects.requireNonNull(getClass().getResource("/TesteWebservices.pfx")).toURI(), "TESTEwebservice");
+
+        var client = new Client(stubServerUrl, webserviceCredentials, webserviceKeys, sslClientCertificate);
+
+        CreateSeriesRequest request = new CreateSeriesRequest();
+        request.setSerie("SFJSJDFLS");
+        request.setMeioProcessamento(SeriesProcessingMedium.COMPUTER_PROGRAM);
+        request.setNumCertSWFatur("999");
+        request.setClasseDoc(DocumentClass.INVOICING_DOCUMENTS);
+        request.setTipoSerie(SeriesType.NORMAL);
+        request.setDataInicioPrevUtiliz(LocalDate.now().plusDays(1));
+        request.setTipoDoc(DocumentType.INVOICE);
+        request.setNumInicialSeq(BigInteger.ONE);
+        final SingleSeriesResponse response = client.createSeries(request);
+
+        Assertions.assertTrue(response.getResultInfo().isSuccess());
+        Assertions.assertEquals("SFJSJDFLS", response.getInfoSerie().getSerie());
+        Assertions.assertEquals("AAJFFSPSWJ", response.getInfoSerie().getCodValidacaoSerie());
+
+    }
+
+    @Test
+    void finalizeSeries() throws Exception {
+
+        webService.setFinalizeSerieCallback(serie -> {
+            final SeriesResp seriesResp = new SeriesResp();
+            final OperationResultInfo infoResultOper = new OperationResultInfo();
+            infoResultOper.setCodResultOper(BigInteger.valueOf(2004));
+            infoResultOper.setMsgResultOper("success");
+            seriesResp.setInfoResultOper(infoResultOper);
+            final SeriesInfo info = new SeriesInfo();
+            info.setSerie(serie);
+            info.setCodValidacaoSerie("AAJFFSPSWJ");
+            seriesResp.setInfoSerie(info);
+            return seriesResp;
+        });
+
+        WebserviceCredentials
+            webserviceCredentials = new WebserviceCredentials("599999993/37", "testes1234");
+        WebserviceKeys webserviceKeys =
+            new WebserviceKeys(Objects.requireNonNull(getClass().getResource("/saPubKey.jks")).toURI(), "saKeyPubPass", "sapubkey.prod");
+
+        SslClientCertificate sslClientCertificate =
+            new SslClientCertificate(Objects.requireNonNull(getClass().getResource("/TesteWebservices.pfx")).toURI(), "TESTEwebservice");
+
+        var client = new Client(stubServerUrl, webserviceCredentials, webserviceKeys, sslClientCertificate);
+
+        FinalizeSeriesRequest request = new FinalizeSeriesRequest();
+        request.setSerie("SFJSJDFLS");
+        request.setClasseDoc(DocumentClass.INVOICING_DOCUMENTS);
+        request.setTipoDoc(DocumentType.INVOICE);
+        request.setJustificacao("some justification 1");
+        request.setCodValidacaoSerie("AAJFFSPSWJ");
+        request.setSeqUltimoDocEmitido(BigInteger.TEN);
+        final SingleSeriesResponse response = client.finalizeSeries(request);
+
+        Assertions.assertTrue(response.getResultInfo().isSuccess());
+        Assertions.assertEquals("SFJSJDFLS", response.getInfoSerie().getSerie());
+        Assertions.assertEquals("AAJFFSPSWJ", response.getInfoSerie().getCodValidacaoSerie());
+
+    }
+
+    @Test
+    void revokeSeries() throws Exception {
+
+        webService.setRevokeSerieCallback(serie -> {
+            final SeriesResp seriesResp = new SeriesResp();
+            final OperationResultInfo infoResultOper = new OperationResultInfo();
+            infoResultOper.setCodResultOper(BigInteger.valueOf(2003));
+            infoResultOper.setMsgResultOper("success");
+            seriesResp.setInfoResultOper(infoResultOper);
+            final SeriesInfo info = new SeriesInfo();
+            info.setSerie(serie);
+            info.setCodValidacaoSerie("AAJFFSPSWJ");
+            seriesResp.setInfoSerie(info);
+            return seriesResp;
+        });
+
+        WebserviceCredentials
+            webserviceCredentials = new WebserviceCredentials("599999993/37", "testes1234");
+        WebserviceKeys webserviceKeys =
+            new WebserviceKeys(Objects.requireNonNull(getClass().getResource("/saPubKey.jks")).toURI(), "saKeyPubPass", "sapubkey.prod");
+
+        SslClientCertificate sslClientCertificate =
+            new SslClientCertificate(Objects.requireNonNull(getClass().getResource("/TesteWebservices.pfx")).toURI(), "TESTEwebservice");
+
+        var client = new Client(stubServerUrl, webserviceCredentials, webserviceKeys, sslClientCertificate);
+
+        RevokeSeriesRequest request = new RevokeSeriesRequest();
+        request.setSerie("SFJSJDFLS");
+        request.setClasseDoc(DocumentClass.INVOICING_DOCUMENTS);
+        request.setTipoDoc(DocumentType.INVOICE);
+        request.setCodValidacaoSerie("AAJFFSPSWJ");
+        request.setMotivo(RevokeJustification.REGISTRATION_ERROR);
+        request.setDeclaracaoNaoEmissao(true);
+        final SingleSeriesResponse response = client.revokeSeries(request);
+
+        Assertions.assertTrue(response.getResultInfo().isSuccess());
+        Assertions.assertEquals("SFJSJDFLS", response.getInfoSerie().getSerie());
+        Assertions.assertEquals("AAJFFSPSWJ", response.getInfoSerie().getCodValidacaoSerie());
+
+    }
+
+    @Test
+    void consultSeries() throws Exception {
+
+        webService.setConsultarSeriesCallback(serie -> {
+            final ConsultSeriesResp consultSeriesResp = new ConsultSeriesResp();
+            final OperationResultInfo infoResultOper = new OperationResultInfo();
+            infoResultOper.setCodResultOper(BigInteger.valueOf(2002));
+            infoResultOper.setMsgResultOper("success");
+            consultSeriesResp.setInfoResultOper(infoResultOper);
+            final SeriesInfo info = new SeriesInfo();
+            info.setSerie("A");
+            consultSeriesResp.getInfoSerie().add(info);
+            return consultSeriesResp;
+        });
+
+        WebserviceCredentials
+            webserviceCredentials = new WebserviceCredentials("599999993/37", "testes1234");
+        WebserviceKeys webserviceKeys =
+            new WebserviceKeys(Objects.requireNonNull(getClass().getResource("/saPubKey.jks")).toURI(), "saKeyPubPass", "sapubkey.prod");
+
+        SslClientCertificate sslClientCertificate =
+            new SslClientCertificate(Objects.requireNonNull(getClass().getResource("/TesteWebservices.pfx")).toURI(), "TESTEwebservice");
+
+        var client = new Client(stubServerUrl, webserviceCredentials, webserviceKeys, sslClientCertificate);
+
+        ConsultSeriesRequest consultSeriesRequest = new ConsultSeriesRequest();
+        consultSeriesRequest.setSerie("A");
+        consultSeriesRequest.setMeioProcessamento(SeriesProcessingMedium.COMPUTER_PROGRAM);
+        final MultipleSeriesResponse response = client.consultSeries(consultSeriesRequest);
+
+        Assertions.assertTrue(response.getResultInfo().isSuccess());
+        Assertions.assertEquals(1, response.getInfoSerie().size());
+
+    }
+
+    private int getFreePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/services/series/webservice/StubSeriesWS.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/services/series/webservice/StubSeriesWS.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy portugal (PT Pack).
+ *
+ * billy portugal (PT Pack) is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy portugal (PT Pack) is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy portugal (PT Pack). If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.portugal.services.series.webservice;
+
+import com.premiumminds.billy.portugal.webservices.series.ConsultSeriesResp;
+import com.premiumminds.billy.portugal.webservices.series.ObjectFactory;
+import com.premiumminds.billy.portugal.webservices.series.SeriesResp;
+import java.math.BigInteger;
+import java.util.function.Function;
+import javax.jws.WebMethod;
+import javax.jws.WebParam;
+import javax.jws.WebResult;
+import javax.jws.WebService;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.ws.Action;
+import javax.xml.ws.RequestWrapper;
+import javax.xml.ws.ResponseWrapper;
+
+@WebService(name = "SeriesWS", targetNamespace = "http://at.gov.pt/")
+@XmlSeeAlso({
+    ObjectFactory.class
+})
+public class StubSeriesWS {
+
+    private Function<String,SeriesResp> registarSerieCallback;
+    private Function<String,SeriesResp> finalizeSerieCallback;
+    private Function<String,SeriesResp> revokeSerieCallback;
+    private Function<String,ConsultSeriesResp> consultarSeriesCallback;
+
+    @WebMethod
+    @WebResult(name = "registarSerieResp", targetNamespace = "")
+    @RequestWrapper(localName = "registarSerie", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.RegistarSerie")
+    @ResponseWrapper(localName = "registarSerieResponse", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.RegistarSerieResponse")
+    @Action(input = "http://at.gov.pt/SeriesWS/registarSerieRequest", output = "http://at.gov.pt/SeriesWS/registarSerieResponse")
+    public SeriesResp registarSerie(
+        @WebParam(name = "serie", targetNamespace = "")
+        String serie,
+        @WebParam(name = "tipoSerie", targetNamespace = "")
+        String tipoSerie,
+        @WebParam(name = "classeDoc", targetNamespace = "")
+        String classeDoc,
+        @WebParam(name = "tipoDoc", targetNamespace = "")
+        String tipoDoc,
+        @WebParam(name = "numInicialSeq", targetNamespace = "") BigInteger numInicialSeq,
+        @WebParam(name = "dataInicioPrevUtiliz", targetNamespace = "")
+        XMLGregorianCalendar dataInicioPrevUtiliz,
+        @WebParam(name = "numCertSWFatur", targetNamespace = "")
+        BigInteger numCertSWFatur,
+        @WebParam(name = "meioProcessamento", targetNamespace = "")
+        String meioProcessamento){
+
+        return registarSerieCallback.apply(serie);
+    }
+
+    @WebMethod
+    @WebResult(name = "finalizarSerieResp", targetNamespace = "")
+    @RequestWrapper(localName = "finalizarSerie", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.FinalizarSerie")
+    @ResponseWrapper(localName = "finalizarSerieResponse", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.FinalizarSerieResponse")
+    @Action(input = "http://at.gov.pt/SeriesWS/finalizarSerieRequest", output = "http://at.gov.pt/SeriesWS/finalizarSerieResponse")
+    public SeriesResp finalizarSerie(
+        @WebParam(name = "serie", targetNamespace = "")
+        String serie,
+        @WebParam(name = "classeDoc", targetNamespace = "")
+        String classeDoc,
+        @WebParam(name = "tipoDoc", targetNamespace = "")
+        String tipoDoc,
+        @WebParam(name = "codValidacaoSerie", targetNamespace = "")
+        String codValidacaoSerie,
+        @WebParam(name = "seqUltimoDocEmitido", targetNamespace = "")
+        BigInteger seqUltimoDocEmitido,
+        @WebParam(name = "justificacao", targetNamespace = "")
+        String justificacao){
+
+        return finalizeSerieCallback.apply(serie);
+    }
+
+    @WebMethod
+    @WebResult(name = "anularSerieResp", targetNamespace = "")
+    @RequestWrapper(localName = "anularSerie", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.AnularSerie")
+    @ResponseWrapper(localName = "anularSerieResponse", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.AnularSerieResponse")
+    @Action(input = "http://at.gov.pt/SeriesWS/anularSerieRequest", output = "http://at.gov.pt/SeriesWS/anularSerieResponse")
+    public SeriesResp anularSerie(
+        @WebParam(name = "serie", targetNamespace = "")
+        String serie,
+        @WebParam(name = "classeDoc", targetNamespace = "")
+        String classeDoc,
+        @WebParam(name = "tipoDoc", targetNamespace = "")
+        String tipoDoc,
+        @WebParam(name = "codValidacaoSerie", targetNamespace = "")
+        String codValidacaoSerie,
+        @WebParam(name = "motivo", targetNamespace = "")
+        String motivo,
+        @WebParam(name = "declaracaoNaoEmissao", targetNamespace = "")
+        boolean declaracaoNaoEmissao){
+
+        return revokeSerieCallback.apply(serie);
+    }
+    @WebMethod
+    @WebResult(name = "consultarSeriesResp", targetNamespace = "")
+    @RequestWrapper(localName = "consultarSeries", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.ConsultarSeries")
+    @ResponseWrapper(localName = "consultarSeriesResponse", targetNamespace = "http://at.gov.pt/", className = "com.premiumminds.billy.portugal.webservices.series.ConsultarSeriesResponse")
+    @Action(input = "http://at.gov.pt/SeriesWS/consultarSeriesRequest", output = "http://at.gov.pt/SeriesWS/consultarSeriesResponse")
+    public ConsultSeriesResp consultarSeries(
+        @WebParam(name = "serie", targetNamespace = "")
+        String serie,
+        @WebParam(name = "tipoSerie", targetNamespace = "")
+        String tipoSerie,
+        @WebParam(name = "classeDoc", targetNamespace = "")
+        String classeDoc,
+        @WebParam(name = "tipoDoc", targetNamespace = "")
+        String tipoDoc,
+        @WebParam(name = "codValidacaoSerie", targetNamespace = "")
+        String codValidacaoSerie,
+        @WebParam(name = "dataRegistoDe", targetNamespace = "") XMLGregorianCalendar dataRegistoDe,
+        @WebParam(name = "dataRegistoAte", targetNamespace = "")
+        XMLGregorianCalendar dataRegistoAte,
+        @WebParam(name = "estado", targetNamespace = "")
+        String estado,
+        @WebParam(name = "meioProcessamento", targetNamespace = "")
+        String meioProcessamento){
+
+        return consultarSeriesCallback.apply(serie);
+    }
+
+    void setRegistarSerieCallback(final Function<String, SeriesResp> registarSerieCallback) {
+        this.registarSerieCallback = registarSerieCallback;
+    }
+    void setFinalizeSerieCallback(final Function<String, SeriesResp> finalizeSerieCallback) {
+        this.finalizeSerieCallback = finalizeSerieCallback;
+    }
+
+    void setRevokeSerieCallback(final Function<String, SeriesResp> revokeSerieCallback) {
+        this.revokeSerieCallback = revokeSerieCallback;
+    }
+
+    void setConsultarSeriesCallback(final Function<String, ConsultSeriesResp> consultarSeriesCallback) {
+        this.consultarSeriesCallback = consultarSeriesCallback;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
 						<exclude>target/**</exclude>
 						<exclude>**/test/resources/keys/**</exclude>
 						<exclude>**/Fatcorews.wsdl</exclude>
+						<exclude>**/Comunicacao_Series.wsdl</exclude>
 					</excludes>
 					<mapping>
 						<java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
continues from #435 

wsdl obtained from
https://info.portaldasfinancas.gov.pt/pt/apoio_contribuinte/Faturacao/Comunicacao_Series_ATCUD/Documents/Comunicacao_Series.wsdl

fixes #437 