### PR TITLE
Allow the manual setting of invoice entry taxes via builder

### DIFF
--- a/billy-andorra/src/main/resources/com/premiumminds/billy/andorra/i18n/FieldNames_ad.properties
+++ b/billy-andorra/src/main/resources/com/premiumminds/billy/andorra/i18n/FieldNames_ad.properties
@@ -134,6 +134,7 @@ field.tax_exemption_reason=Motiu de l'Exempció d'Impost
 field.discount_type=Tipus de Descompte
 field.invoice_reference=Referència per a la Factura
 field.reason=Motiu de l'Emissió de la Nota d'Abonament
+field.taxes=Impostos
 
 #Product
 field.product_code=Codi del Producte

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.persistence.entities.jpa;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
@@ -368,6 +369,12 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
     @Override
     public void setExchangeRateToDocumentCurrency(BigDecimal rate) {
         this.exchangeRateToDocumentCurrency = rate;
+    }
+
+    @Override
+    public <T extends Tax> void setTaxes(final Collection<T> taxes) {
+        this.taxes.clear();
+        this.taxes.addAll(taxes);
     }
 
     @Override

--- a/billy-core/src/main/java/com/premiumminds/billy/core/persistence/entities/GenericInvoiceEntryEntity.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/persistence/entities/GenericInvoiceEntryEntity.java
@@ -19,6 +19,7 @@
 package com.premiumminds.billy.core.persistence.entities;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
@@ -78,6 +79,8 @@ public interface GenericInvoiceEntryEntity extends GenericInvoiceEntry {
 
     @Override
     public <T extends Tax> List<T> getTaxes();
+
+    public <T extends Tax> void setTaxes(Collection<T> taxes);
 
     public void setTaxExemptionReason(String exemptionReason);
 

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/GenericInvoiceEntryBuilder.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/GenericInvoiceEntryBuilder.java
@@ -23,10 +23,12 @@ import com.premiumminds.billy.core.services.StringID;
 import com.premiumminds.billy.core.services.entities.Context;
 import com.premiumminds.billy.core.services.entities.Product;
 import com.premiumminds.billy.core.services.entities.ShippingPoint;
+import com.premiumminds.billy.core.services.entities.Tax;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
 import com.premiumminds.billy.core.util.DiscountType;
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Currency;
 import java.util.Date;
 
@@ -69,5 +71,7 @@ public interface GenericInvoiceEntryBuilder<TBuilder extends GenericInvoiceEntry
     TBuilder setAmountType(AmountType type);
 
     TBuilder setCurrency(Currency currency);
+
+    <T extends Tax> TBuilder setTaxes(Collection<T> taxes);
 
 }

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/fixtures/MockGenericInvoiceEntryEntity.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/fixtures/MockGenericInvoiceEntryEntity.java
@@ -20,6 +20,7 @@ package com.premiumminds.billy.core.test.fixtures;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Currency;
 import java.util.Date;
 import java.util.List;
@@ -286,6 +287,12 @@ public class MockGenericInvoiceEntryEntity extends MockBaseEntity<GenericInvoice
     @Override
     public void setExchangeRateToDocumentCurrency(BigDecimal rate) {
         this.exchangeRateToDocumentCurrency = rate;
+    }
+
+    @Override
+    public <T extends Tax> void setTaxes(final Collection<T> taxes) {
+        this.taxes.clear();
+        this.taxes.addAll(taxes);
     }
 
     @Override

--- a/billy-core/src/test/resources/yml/GenericInvoiceEntryReuseTaxes.yml
+++ b/billy-core/src/test/resources/yml/GenericInvoiceEntryReuseTaxes.yml
@@ -1,0 +1,129 @@
+#
+# Copyright (C) 2017 Premium Minds.
+#
+# This file is part of billy core.
+#
+# billy core is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
+# later version.
+#
+# billy core is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with billy core. If not, see <http://www.gnu.org/licenses/>.
+#
+
+uid : genericEntry_uid
+creditOrDebit : CREDIT
+description : description
+number : 143
+exchangeRateToDocumentCurrency : !!java.math.BigDecimal
+  1
+amountWithoutTax : !!java.math.BigDecimal
+  1590.082
+amountWithTax : !!java.math.BigDecimal
+  1955.80086
+taxAmount : !!java.math.BigDecimal
+  365.71886
+discountAmount : !!java.math.BigDecimal
+  0
+product : !!com.premiumminds.billy.core.test.fixtures.MockProductEntity
+    uid : product_uid
+    productCode : product_code
+    productGroup : product_group
+    unitOfMeasure : unit_of_measure
+    numberCode : number_code
+    comodityCode : comodity_code
+    type : GOODS
+    description : product_description
+    valuationMethod : valuation_method
+    taxes:
+      - !!com.premiumminds.billy.core.test.fixtures.MockTaxEntity
+        uid : UID_TAX
+        designation : desgination_1
+        description : description_1
+        code : VAT
+        value : 7.95041
+        validFrom: 2013-01-01
+        validTo: 2013-12-12
+        taxRateType : PERCENTAGE
+        percentageRateValue : 23
+        flatRateAmount : 7.95041
+        context : !!com.premiumminds.billy.core.test.fixtures.MockContextEntity
+          uid : Context_uid
+          name : PT
+          description : PT
+          parentContext : !!com.premiumminds.billy.core.test.fixtures.MockContextEntity
+            uid : context_parent_uid
+            name : PT
+            description : PT
+
+quantity : !!java.math.BigDecimal
+  46
+shippingCostsAmount : !!java.math.BigDecimal
+  0
+shippingDestination : !!com.premiumminds.billy.core.test.fixtures.MockShippingPointEntity
+  deliveryId : delivery_id
+  warehouseId : warehouse_id
+  locationId : location_id
+  UCR : ucr
+  date : 2013-01-01
+  address : !!com.premiumminds.billy.core.test.fixtures.MockAddressEntity
+    streetName : street_name
+    number : number
+    details : details
+    building : building
+    city : city
+    postalCode : postal_code
+    region : region
+    country : country
+shippingOrigin : !!com.premiumminds.billy.core.test.fixtures.MockShippingPointEntity
+  deliveryId : delivery_id
+  warehouseId : warehouse_id
+  locationId : location_id
+  UCR : ucr
+  date : 2013-01-01
+  address : !!com.premiumminds.billy.core.test.fixtures.MockAddressEntity
+    streetName : street_name
+    number : number
+    details : details
+    building : building
+    city : city
+    postalCode : postal_code
+    region : region
+    country : country
+taxes:
+  - !!com.premiumminds.billy.core.test.fixtures.MockTaxEntity
+    uid: UID_TAX
+    designation: desgination_1
+    description: description_1
+    code: VAT
+    value: 7.95041
+    validFrom: 2013-01-01
+    validTo: 2013-12-12
+    taxRateType: PERCENTAGE
+    percentageRateValue: 23
+    flatRateAmount: 7.95041
+    context: !!com.premiumminds.billy.core.test.fixtures.MockContextEntity
+      uid: Context_uid
+      name: PT
+      description: PT
+      parentContext: !!com.premiumminds.billy.core.test.fixtures.MockContextEntity
+        uid: context_parent_uid
+        name: PT
+        description: PT
+taxExemptionReason : exemption_reason
+taxPointDate : 2013-10-20
+unitAmountWithoutTax : !!java.math.BigDecimal
+  34.567
+unitAmountWithTax : !!java.math.BigDecimal
+  42.51741
+unitTaxAmount : !!java.math.BigDecimal
+  7.95041
+unitDiscountAmount : !!java.math.BigDecimal
+  0
+unitOfMeasure : kg

--- a/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
+++ b/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
@@ -132,6 +132,7 @@ field.tax_exemption_reason=Motif de l'exonération fiscale
 field.discount_type=Type de remise
 field.invoice_reference=Référence à la facture
 field.reason=Raison de l'émission de note de crédit
+field.taxes=Impôts
 
 #Product
 field.product_code=Code produit

--- a/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
+++ b/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
@@ -136,6 +136,7 @@ field.tax_exemption_code=Codigo da Isencao de Imposto
 field.discount_type=Tipo de Desconto
 field.invoice_reference=Referência para a Factura
 field.reason=Razão da Emissão da Nota de Crédito
+field.taxes=Impostos
 
 #Payment
 field.payment_amount=Valor do Pagamento

--- a/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
+++ b/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
@@ -134,6 +134,7 @@ field.tax_exemption_reason=Motivo de la Exención de Impuesto
 field.discount_type=Tipo de Descuento
 field.invoice_reference=Referencia para la Factura
 field.reason=Motivo de la Emisión de la Nota de Abono
+field.taxes=Impuestos
 
 #Product
 field.product_code=Código del Producto


### PR DESCRIPTION
When taxes are set this way, billy won't determine the taxes for the entry given the taxpoint date and the context. Instead it will just check that the given taxes are valid for the given taxpoint date