### PR TITLE
Modified issuing logic for better concurrent issue handling

### DIFF
--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/TestConcurrentIssuing.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/TestConcurrentIssuing.java
@@ -79,8 +79,7 @@ public class TestConcurrentIssuing extends ADDocumentAbstractTest {
                         TestConcurrentIssuing.this.parameters);
                 return invoice;
             } catch (DocumentIssuingException e) {
-                System.out.println(e.getMessage());
-                return null;
+                throw new RuntimeException(e);
             }
         }
     }
@@ -111,12 +110,14 @@ public class TestConcurrentIssuing extends ADDocumentAbstractTest {
         ADInvoiceEntity latestInvoice1 = this.getInstance(DAOADInvoice.class).getLatestInvoiceFromSeries("A", B1);
         Assertions.assertNotNull(entity1);
         Assertions.assertEquals(entity1.getSeriesNumber(), latestInvoice1.getSeriesNumber());
+        Assertions.assertEquals(entity1.getLocalDate(), latestInvoice1.getLocalDate());
         Assertions.assertEquals(entity1.getBusiness().getUID(), B1);
 
         ADInvoiceEntity entity2 = this.getLatestInvoice(invoices2);
         ADInvoiceEntity latestInvoice2 = this.getInstance(DAOADInvoice.class).getLatestInvoiceFromSeries("A", B2);
         Assertions.assertNotNull(entity2);
         Assertions.assertEquals(entity2.getSeriesNumber(), latestInvoice2.getSeriesNumber());
+        Assertions.assertEquals(entity2.getLocalDate(), latestInvoice2.getLocalDate());
         Assertions.assertEquals(entity2.getBusiness().getUID(), B2);
 
     }

--- a/billy-france/src/main/java/com/premiumminds/billy/france/services/documents/FRGenericInvoiceIssuingHandler.java
+++ b/billy-france/src/main/java/com/premiumminds/billy/france/services/documents/FRGenericInvoiceIssuingHandler.java
@@ -22,6 +22,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
 
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.persistence.LockModeType;
 
@@ -58,6 +59,10 @@ public abstract class FRGenericInvoiceIssuingHandler<T extends FRGenericInvoiceE
 
         // If the date is null then the invoice date is the current date
         Date invoiceDate = document.getDate() == null ? new Date() : document.getDate();
+        ZoneId timezone = document.getBusiness().getTimezone();
+        LocalDate issueLocalDate = document.getLocalDate() == null ?
+            LocalDate.ofInstant(invoiceDate.toInstant(), timezone) :
+            document.getLocalDate();
 
         Integer seriesNumber = 1;
 
@@ -66,20 +71,20 @@ public abstract class FRGenericInvoiceIssuingHandler<T extends FRGenericInvoiceE
 
         if (null != latestInvoice) {
             seriesNumber = latestInvoice.getSeriesNumber() + 1;
-            Date latestInvoiceDate = latestInvoice.getDate();
 
-            if (latestInvoiceDate.compareTo(invoiceDate) > 0) {
+            final LocalDate latestLocalDate = Optional
+                .ofNullable(latestInvoice.getLocalDate())
+                .orElseGet(() -> latestInvoice
+                    .getDate()
+                    .toInstant()
+                    .atZone(latestInvoice.getBusiness().getTimezone())
+                    .toLocalDate());
+            if (latestLocalDate.isAfter(issueLocalDate)) {
                 throw new InvalidInvoiceDateException();
             }
         }
 
         String formatedNumber = parametersFR.getInvoiceSeries() + "/" + seriesNumber;
-
-        ZoneId timezone = document.getBusiness().getTimezone();
-        LocalDate issueLocalDate =
-            document.getLocalDate() == null ?
-                LocalDate.ofInstant(invoiceDate.toInstant(), timezone) :
-                document.getLocalDate();
 
         document.setDate(invoiceDate);
         document.setNumber(formatedNumber);

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/TestConcurrentIssuing.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/TestConcurrentIssuing.java
@@ -78,8 +78,7 @@ public class TestConcurrentIssuing extends FRDocumentAbstractTest {
                         TestConcurrentIssuing.this.parameters);
                 return invoice;
             } catch (DocumentIssuingException e) {
-                System.out.println(e.getMessage());
-                return null;
+                throw new RuntimeException(e);
             }
         }
     }
@@ -114,12 +113,14 @@ public class TestConcurrentIssuing extends FRDocumentAbstractTest {
         FRInvoiceEntity latestInvoice1 = this.getInstance(DAOFRInvoice.class).getLatestInvoiceFromSeries("A", B1);
         Assertions.assertNotNull(entity1);
         Assertions.assertEquals(entity1.getSeriesNumber(), latestInvoice1.getSeriesNumber());
+        Assertions.assertEquals(entity1.getLocalDate(), latestInvoice1.getLocalDate());
         Assertions.assertEquals(entity1.getBusiness().getUID(), B1);
 
         FRInvoiceEntity entity2 = this.getLatestInvoice(invoices2);
         FRInvoiceEntity latestInvoice2 = this.getInstance(DAOFRInvoice.class).getLatestInvoiceFromSeries("A", B2);
         Assertions.assertNotNull(entity2);
         Assertions.assertEquals(entity2.getSeriesNumber(), latestInvoice2.getSeriesNumber());
+        Assertions.assertEquals(entity2.getLocalDate(), latestInvoice2.getLocalDate());
         Assertions.assertEquals(entity2.getBusiness().getUID(), B2);
 
     }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/GenerateHash.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/util/GenerateHash.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Date;
 
 import com.premiumminds.billy.core.services.exceptions.DocumentIssuingException;
@@ -30,9 +31,15 @@ import com.premiumminds.billy.portugal.services.certification.CertificationManag
 
 public class GenerateHash {
 
-    public static String generateHash(PrivateKey privateKey, PublicKey publicKey,
-            Date invoiceDate, Date systemEntryDate, String invoiceNumber,
-            BigDecimal grossTotal, String previousInvoiceHash) throws DocumentIssuingException {
+    public static String generateHash(
+        PrivateKey privateKey,
+        PublicKey publicKey,
+        LocalDate invoiceDate,
+        Date systemEntryDate,
+        String invoiceNumber,
+        BigDecimal grossTotal,
+        String previousInvoiceHash) throws DocumentIssuingException
+    {
 
         try {
             String sourceString = GenerateHash.generateSourceHash(invoiceDate, systemEntryDate, invoiceNumber,
@@ -49,14 +56,13 @@ public class GenerateHash {
         }
     }
 
-    public static String generateSourceHash(Date invoiceDate, Date systemEntryDate, String invoiceNumber,
+    public static String generateSourceHash(LocalDate invoiceDate, Date systemEntryDate, String invoiceNumber,
             BigDecimal grossTotal, String previousInvoiceHash) {
 
-        SimpleDateFormat date = new SimpleDateFormat("yyyy-MM-dd");
         SimpleDateFormat dateTime = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
         StringBuilder builder = new StringBuilder();
-        builder.append(date.format(invoiceDate)).append(';').append(dateTime.format(systemEntryDate)).append(';')
+        builder.append(invoiceDate).append(';').append(dateTime.format(systemEntryDate)).append(';')
                 .append(invoiceNumber).append(';')
                 .append(grossTotal.setScale(BillyMathContext.SCALE, BillyMathContext.get().getRoundingMode()))
                 .append(';').append(previousInvoiceHash == null ? "" : previousInvoiceHash);

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/TestConcurrentIssuing.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/TestConcurrentIssuing.java
@@ -79,8 +79,7 @@ public class TestConcurrentIssuing extends PTDocumentAbstractTest {
                         TestConcurrentIssuing.this.parameters);
                 return invoice;
             } catch (DocumentIssuingException e) {
-                System.out.println(e.getMessage());
-                return null;
+                throw new RuntimeException(e);
             }
         }
     }
@@ -115,12 +114,14 @@ public class TestConcurrentIssuing extends PTDocumentAbstractTest {
         PTInvoiceEntity latestInvoice1 = this.getInstance(DAOPTInvoice.class).getLatestInvoiceFromSeries("A", B1);
         Assertions.assertNotNull(entity1);
         Assertions.assertEquals(entity1.getSeriesNumber(), latestInvoice1.getSeriesNumber());
+        Assertions.assertEquals(entity1.getLocalDate(), latestInvoice1.getLocalDate());
         Assertions.assertEquals(entity1.getBusiness().getUID(), B1);
 
         PTInvoiceEntity entity2 = this.getLatestInvoice(invoices2);
         PTInvoiceEntity latestInvoice2 = this.getInstance(DAOPTInvoice.class).getLatestInvoiceFromSeries("A", B2);
         Assertions.assertNotNull(entity2);
         Assertions.assertEquals(entity2.getSeriesNumber(), latestInvoice2.getSeriesNumber());
+        Assertions.assertEquals(entity2.getLocalDate(), latestInvoice2.getLocalDate());
         Assertions.assertEquals(entity2.getBusiness().getUID(), B2);
     }
 

--- a/billy-spain/src/main/java/com/premiumminds/billy/spain/services/documents/ESGenericInvoiceIssuingHandler.java
+++ b/billy-spain/src/main/java/com/premiumminds/billy/spain/services/documents/ESGenericInvoiceIssuingHandler.java
@@ -30,6 +30,7 @@ import com.premiumminds.billy.spain.services.documents.util.ESIssuingParams;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Date;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.persistence.LockModeType;
 
@@ -56,6 +57,10 @@ public abstract class ESGenericInvoiceIssuingHandler<T extends ESGenericInvoiceE
 
         // If the date is null then the invoice date is the current date
         Date invoiceDate = document.getDate() == null ? new Date() : document.getDate();
+        ZoneId timezone = document.getBusiness().getTimezone();
+        LocalDate issueLocalDate = document.getLocalDate() == null ?
+            LocalDate.ofInstant(invoiceDate.toInstant(), timezone) :
+            document.getLocalDate();
 
         Integer seriesNumber = 1;
 
@@ -64,20 +69,20 @@ public abstract class ESGenericInvoiceIssuingHandler<T extends ESGenericInvoiceE
 
         if (null != latestInvoice) {
             seriesNumber = latestInvoice.getSeriesNumber() + 1;
-            Date latestInvoiceDate = latestInvoice.getDate();
 
-            if (latestInvoiceDate.compareTo(invoiceDate) > 0) {
+            final LocalDate latestLocalDate = Optional
+                .ofNullable(latestInvoice.getLocalDate())
+                .orElseGet(() -> latestInvoice
+                    .getDate()
+                    .toInstant()
+                    .atZone(latestInvoice.getBusiness().getTimezone())
+                    .toLocalDate());
+            if (latestLocalDate.isAfter(issueLocalDate)) {
                 throw new InvalidInvoiceDateException();
             }
         }
 
         String formatedNumber = parametersES.getInvoiceSeries() + "/" + seriesNumber;
-
-        ZoneId timezone = document.getBusiness().getTimezone();
-        LocalDate issueLocalDate =
-            document.getLocalDate() == null ?
-                LocalDate.ofInstant(invoiceDate.toInstant(), timezone) :
-                document.getLocalDate();
 
         document.setDate(invoiceDate);
         document.setNumber(formatedNumber);

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/TestConcurrentIssuing.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/TestConcurrentIssuing.java
@@ -78,8 +78,7 @@ public class TestConcurrentIssuing extends ESDocumentAbstractTest {
                         TestConcurrentIssuing.this.parameters);
                 return invoice;
             } catch (DocumentIssuingException e) {
-                System.out.println(e.getMessage());
-                return null;
+                throw new RuntimeException(e);
             }
         }
     }
@@ -110,12 +109,14 @@ public class TestConcurrentIssuing extends ESDocumentAbstractTest {
         ESInvoiceEntity latestInvoice1 = this.getInstance(DAOESInvoice.class).getLatestInvoiceFromSeries("A", B1);
         Assertions.assertNotNull(entity1);
         Assertions.assertEquals(entity1.getSeriesNumber(), latestInvoice1.getSeriesNumber());
+        Assertions.assertEquals(entity1.getLocalDate(), latestInvoice1.getLocalDate());
         Assertions.assertEquals(entity1.getBusiness().getUID(), B1);
 
         ESInvoiceEntity entity2 = this.getLatestInvoice(invoices2);
         ESInvoiceEntity latestInvoice2 = this.getInstance(DAOESInvoice.class).getLatestInvoiceFromSeries("A", B2);
         Assertions.assertNotNull(entity2);
         Assertions.assertEquals(entity2.getSeriesNumber(), latestInvoice2.getSeriesNumber());
+        Assertions.assertEquals(entity2.getLocalDate(), latestInvoice2.getLocalDate());
         Assertions.assertEquals(entity2.getBusiness().getUID(), B2);
 
     }


### PR DESCRIPTION
The previous versions were not properly supporting concurrent issuing, as they were comparing the instants (to the millisecond) and the law refers only to the date. Therefore, the changes were made so that only the issuing local date is used when comparing to the last issued document for that business.