### PR TITLE
Set wsdl file location with wsdlLocation parameter

### DIFF
--- a/billy-portugal/pom.xml
+++ b/billy-portugal/pom.xml
@@ -298,6 +298,7 @@
 							<wsdlFiles>
 								<wsdlFile>Fatcorews.wsdl</wsdlFile>
 							</wsdlFiles>
+							<wsdlLocation>/Fatcorews.wsdl</wsdlLocation>
 							<packageName>com.premiumminds.billy.portugal.webservices.documents</packageName>
 							<sourceDestDir>src-generated/main/java</sourceDestDir>
 						</configuration>
@@ -312,6 +313,7 @@
 							<wsdlFiles>
 								<wsdlFile>Comunicacao_Series.wsdl</wsdlFile>
 							</wsdlFiles>
+							<wsdlLocation>/Comunicacao_Series.wsdl</wsdlLocation>
 							<packageName>com.premiumminds.billy.portugal.webservices.series</packageName>
 							<sourceDestDir>src-generated/main/java</sourceDestDir>
 						</configuration>


### PR DESCRIPTION
If not set this way, it will default to the path to wsdl in the host machine that published a release which is very bad.

Use wsdl files in resources folders as the targets