### PR TITLE
Removes @Inheritance from JPABaseEntity

### DIFF
--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPABaseEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPABaseEntity.java
@@ -25,19 +25,16 @@ import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
-import org.apache.commons.lang3.Validate;
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.services.StringID;
 import com.premiumminds.billy.core.services.entities.Entity;
+import org.apache.commons.lang3.Validate;
+import org.hibernate.envers.Audited;
 
 /**
  * @author Francisco Vargas
@@ -46,7 +43,6 @@ import com.premiumminds.billy.core.services.entities.Entity;
  */
 @MappedSuperclass
 @Audited
-@Inheritance(strategy = InheritanceType.JOINED)
 public abstract class JPABaseEntity<E> implements Entity<E> {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Fixes Hibernate warning:
HHH000503: A class should not be annotated with both @Inheritance and @MappedSuperclass. @Inheritance will be ignored for: com.premiumminds.billy.core.persistence.entities.jpa.JPABaseEntity

https://hibernate.atlassian.net/browse/HHH-13217
Don't throw exception if both @MappedSuperclass and @Inheritance are used

Fixes #164 