### PR TITLE
Removes e.printStackTrace()

### DIFF
--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/ADPersistencyAbstractTest.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/ADPersistencyAbstractTest.java
@@ -85,10 +85,8 @@ public class ADPersistencyAbstractTest extends ADAbstractTest {
                             new ADBusinessTestUtil(ADAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public ADReceiptEntity getNewIssuedReceipt(StringID<Business> businessUID) {
@@ -103,9 +101,8 @@ public class ADPersistencyAbstractTest extends ADAbstractTest {
                             new ADBusinessTestUtil(ADAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     public ADCreditReceiptEntity getNewIssuedCreditReceipt(ADReceipt receipt) {
@@ -121,10 +118,8 @@ public class ADPersistencyAbstractTest extends ADAbstractTest {
                     new ADCreditReceiptTestUtil(ADAbstractTest.injector).getCreditReceiptBuilder((ADReceiptEntity) receipt),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public ADCreditNoteEntity getNewIssuedCreditnote(ADInvoice reference) {
@@ -140,10 +135,8 @@ public class ADPersistencyAbstractTest extends ADAbstractTest {
                     new ADCreditNoteTestUtil(ADAbstractTest.injector).getCreditNoteBuilder((ADInvoiceEntity) reference),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     protected ADIssuingParams getParameters(String series, String EACCode) {

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADInvoiceIssuingHandler.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADInvoiceIssuingHandler.java
@@ -52,9 +52,8 @@ public class TestADInvoiceIssuingHandler extends ADDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
     }
 
     @Test

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADManualInvoiceIssuingHandler.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADManualInvoiceIssuingHandler.java
@@ -51,7 +51,7 @@ public class TestADManualInvoiceIssuingHandler extends ADDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADReceiptIssuingHandler.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADReceiptIssuingHandler.java
@@ -52,7 +52,7 @@ public class TestADReceiptIssuingHandler extends ADDocumentAbstractTest {
 
             this.issuedReceiptUID = receipt.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADSimpleInvoiceIssuingHandler.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/services/documents/handler/TestADSimpleInvoiceIssuingHandler.java
@@ -56,7 +56,7 @@ class TestADSimpleInvoiceIssuingHandler extends ADDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/util/ADBusinessTestUtil.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/test/util/ADBusinessTestUtil.java
@@ -81,7 +81,7 @@ public class ADBusinessTestUtil {
         try {
             applicationBuilder = this.application.getApplicationBuilder();
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         ADContact.Builder contactBuilder = this.contact.getContactBuilder();

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/FRPersistencyAbstractTest.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/FRPersistencyAbstractTest.java
@@ -85,10 +85,8 @@ public class FRPersistencyAbstractTest extends FRAbstractTest {
                             new FRBusinessTestUtil(FRAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public FRReceiptEntity getNewIssuedReceipt(StringID<Business> businessUID) {
@@ -103,9 +101,8 @@ public class FRPersistencyAbstractTest extends FRAbstractTest {
                             new FRBusinessTestUtil(FRAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-      return null;
     }
 
     public FRCreditReceiptEntity getNewIssuedCreditReceipt(FRReceipt receipt) {
@@ -121,10 +118,8 @@ public class FRPersistencyAbstractTest extends FRAbstractTest {
                     new FRCreditReceiptTestUtil(FRAbstractTest.injector).getCreditReceiptBuilder((FRReceiptEntity) receipt),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public FRCreditNoteEntity getNewIssuedCreditnote(FRInvoice reference) {
@@ -139,10 +134,8 @@ public class FRPersistencyAbstractTest extends FRAbstractTest {
                     new FRCreditNoteTestUtil(FRAbstractTest.injector).getCreditNoteBuilder((FRInvoiceEntity) reference),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     protected FRIssuingParams getParameters(String series, String EACCode) {

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRInvoiceIssuingHandler.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRInvoiceIssuingHandler.java
@@ -54,7 +54,7 @@ public class TestFRInvoiceIssuingHandler extends FRDocumentAbstractTest {
             this.issuedInvoiceUID = invoice.getUID();
 
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
     }

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRManualInvoiceIssuingHandler.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRManualInvoiceIssuingHandler.java
@@ -51,7 +51,7 @@ public class TestFRManualInvoiceIssuingHandler extends FRDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRReceiptIssuingHandler.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRReceiptIssuingHandler.java
@@ -51,7 +51,7 @@ public class TestFRReceiptIssuingHandler extends FRDocumentAbstractTest {
             this.issueNewInvoice(this.handler, receipt, this.DEFAULT_SERIES);
             this.issuedReceiptUID = receipt.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRSimpleInvoiceIssuingHandler.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/services/documents/handler/TestFRSimpleInvoiceIssuingHandler.java
@@ -57,7 +57,7 @@ public class TestFRSimpleInvoiceIssuingHandler extends FRDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRBusinessTestUtil.java
+++ b/billy-france/src/test/java/com/premiumminds/billy/france/test/util/FRBusinessTestUtil.java
@@ -81,7 +81,7 @@ public class FRBusinessTestUtil {
         try {
             applicationBuilder = this.application.getApplicationBuilder();
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         FRContact.Builder contactBuilder = this.contact.getContactBuilder();

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/webservice/AuthenticationHandler.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/export/webservice/AuthenticationHandler.java
@@ -49,7 +49,12 @@ import javax.xml.ws.handler.MessageContext;
 import javax.xml.ws.handler.soap.SOAPHandler;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class AuthenticationHandler implements SOAPHandler<SOAPMessageContext>  {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationHandler.class);
 
     private static final String AUTH_NS = "http://schemas.xmlsoap.org/ws/2002/12/secext";
     private static final String AUTH_PREFIX = "wss";
@@ -94,7 +99,7 @@ class AuthenticationHandler implements SOAPHandler<SOAPMessageContext>  {
                         webserviceCredentials.getUsername());
 
             } catch (Exception e){
-                e.printStackTrace();
+                LOGGER.error("problem with authentication", e);
                 return false;
             }
         }

--- a/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/AuthenticationHandler.java
+++ b/billy-portugal/src/main/java/com/premiumminds/billy/portugal/services/series/webservice/AuthenticationHandler.java
@@ -49,7 +49,12 @@ import javax.xml.ws.handler.MessageContext;
 import javax.xml.ws.handler.soap.SOAPHandler;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 class AuthenticationHandler implements SOAPHandler<SOAPMessageContext>  {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationHandler.class);
 
     private static final String AUTH_NS = "http://schemas.xmlsoap.org/ws/2002/12/secext";
     private static final String AUTH_PREFIX = "wss";
@@ -94,7 +99,7 @@ class AuthenticationHandler implements SOAPHandler<SOAPMessageContext>  {
                         webserviceCredentials.getUsername());
 
             } catch (Exception e){
-                e.printStackTrace();
+                LOGGER.error("problem with authentication", e);
                 return false;
             }
         }

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/PTPersistencyAbstractTest.java
@@ -80,10 +80,8 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
                     new PTBusinessTestUtil(PTAbstractTest.injector).getBusinessEntity(businessUID), SourceBilling.P),
                 parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public PTCreditNoteEntity getNewIssuedCreditnote(PTInvoice reference) {
@@ -97,10 +95,8 @@ public class PTPersistencyAbstractTest extends PTAbstractTest {
                 new PTCreditNoteTestUtil(PTAbstractTest.injector).getCreditNoteBuilder((PTInvoiceEntity) reference),
                 parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     protected PTIssuingParams getParameters(String series, String EACCode, String privateKeyVersion) {

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTInvoiceIssuingHandler.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTInvoiceIssuingHandler.java
@@ -62,9 +62,8 @@ public class TestPTInvoiceIssuingHandler extends PTDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, PTPersistencyAbstractTest.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
     }
 
     @Test

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTManualInvoiceIssuingHandler.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTManualInvoiceIssuingHandler.java
@@ -55,7 +55,7 @@ public class TestPTManualInvoiceIssuingHandler extends PTDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, PTPersistencyAbstractTest.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTReceiptInvoiceIssuingHandler.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTReceiptInvoiceIssuingHandler.java
@@ -55,9 +55,8 @@ public class TestPTReceiptInvoiceIssuingHandler extends PTDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, PTPersistencyAbstractTest.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
     }
 
     @Test

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTSimpleInvoiceIssuingHandler.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/services/documents/handler/TestPTSimpleInvoiceIssuingHandler.java
@@ -59,7 +59,7 @@ class TestPTSimpleInvoiceIssuingHandler extends PTDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, PTPersistencyAbstractTest.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTBusinessTestUtil.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/test/util/PTBusinessTestUtil.java
@@ -81,7 +81,7 @@ public class PTBusinessTestUtil {
         try {
             applicationBuilder = this.application.getApplicationBuilder();
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         PTContact.Builder contactBuilder = this.contact.getContactBuilder();

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/ESPersistencyAbstractTest.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/ESPersistencyAbstractTest.java
@@ -85,10 +85,8 @@ public class ESPersistencyAbstractTest extends ESAbstractTest {
                             new ESBusinessTestUtil(ESAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public ESReceiptEntity getNewIssuedReceipt(StringID<Business> businessUID) {
@@ -103,9 +101,8 @@ public class ESPersistencyAbstractTest extends ESAbstractTest {
                             new ESBusinessTestUtil(ESAbstractTest.injector).getBusinessEntity(businessUID)),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     public ESCreditReceiptEntity getNewIssuedCreditReceipt(ESReceipt receipt) {
@@ -121,10 +118,8 @@ public class ESPersistencyAbstractTest extends ESAbstractTest {
                     new ESCreditReceiptTestUtil(ESAbstractTest.injector).getCreditReceiptBuilder((ESReceiptEntity) receipt),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     public ESCreditNoteEntity getNewIssuedCreditnote(ESInvoice reference) {
@@ -140,10 +135,8 @@ public class ESPersistencyAbstractTest extends ESAbstractTest {
                     new ESCreditNoteTestUtil(ESAbstractTest.injector).getCreditNoteBuilder((ESInvoiceEntity) reference),
                     parameters);
         } catch (DocumentIssuingException | SeriesUniqueCodeNotFilled | DocumentSeriesDoesNotExistException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     protected ESIssuingParams getParameters(String series, String EACCode) {

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESInvoiceIssuingHandler.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESInvoiceIssuingHandler.java
@@ -52,9 +52,8 @@ public class TestESInvoiceIssuingHandler extends ESDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-
     }
 
     @Test

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESManualInvoiceIssuingHandler.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESManualInvoiceIssuingHandler.java
@@ -51,7 +51,7 @@ public class TestESManualInvoiceIssuingHandler extends ESDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, this.DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESReceiptIssuingHandler.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESReceiptIssuingHandler.java
@@ -52,7 +52,7 @@ public class TestESReceiptIssuingHandler extends ESDocumentAbstractTest {
 
             this.issuedReceiptUID = receipt.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESSimpleInvoiceIssuingHandler.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/services/documents/handler/TestESSimpleInvoiceIssuingHandler.java
@@ -56,7 +56,7 @@ class TestESSimpleInvoiceIssuingHandler extends ESDocumentAbstractTest {
             this.issueNewInvoice(this.handler, invoice, DEFAULT_SERIES);
             this.issuedInvoiceUID = invoice.getUID();
         } catch (DocumentIssuingException | DocumentSeriesDoesNotExistException | SeriesUniqueCodeNotFilled e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESBusinessTestUtil.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/test/util/ESBusinessTestUtil.java
@@ -81,7 +81,7 @@ public class ESBusinessTestUtil {
         try {
             applicationBuilder = this.application.getApplicationBuilder();
         } catch (MalformedURLException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         ESContact.Builder contactBuilder = this.contact.getContactBuilder();


### PR DESCRIPTION
e.printStackTrace() is a bad practice and should replaced with proper exception handling and/or logging.

https://stackoverflow.com/questions/7469316/why-is-exception-printstacktrace-considered-bad-practice

Fixes #379 