### PR TITLE
Adds external id field to generic invoice entry

### DIFF
--- a/billy-andorra/src/main/resources/com/premiumminds/billy/andorra/i18n/FieldNames_ad.properties
+++ b/billy-andorra/src/main/resources/com/premiumminds/billy/andorra/i18n/FieldNames_ad.properties
@@ -135,6 +135,7 @@ field.discount_type=Tipus de Descompte
 field.invoice_reference=Referència per a la Factura
 field.reason=Motiu de l'Emissió de la Nota d'Abonament
 field.taxes=Impostos
+field.external_id=ID Extern
 
 #Product
 field.product_code=Codi del Producte

--- a/billy-andorra/src/test/java/com/premiumminds/billy/andorra/its/InvoiceIT.java
+++ b/billy-andorra/src/test/java/com/premiumminds/billy/andorra/its/InvoiceIT.java
@@ -18,8 +18,6 @@
  */
 package com.premiumminds.billy.andorra.its;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.premiumminds.billy.andorra.AndorraBootstrap;
@@ -41,6 +39,7 @@ import com.premiumminds.billy.andorra.services.entities.ADInvoiceEntry;
 import com.premiumminds.billy.andorra.services.entities.ADPayment;
 import com.premiumminds.billy.andorra.services.entities.ADProduct;
 import com.premiumminds.billy.andorra.services.entities.ADTax;
+import com.premiumminds.billy.core.ExternalID;
 import com.premiumminds.billy.core.exceptions.SeriesUniqueCodeNotFilled;
 import com.premiumminds.billy.core.persistence.dao.DAOInvoiceSeries;
 import com.premiumminds.billy.core.persistence.entities.InvoiceSeriesEntity;
@@ -52,13 +51,16 @@ import com.premiumminds.billy.core.services.exceptions.DocumentIssuingException;
 import com.premiumminds.billy.core.services.exceptions.DocumentSeriesDoesNotExistException;
 import com.premiumminds.billy.core.util.PaymentMechanism;
 import com.premiumminds.billy.persistence.entities.jpa.JPAInvoiceSeriesEntity;
+import org.junit.jupiter.api.Test;
+
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Currency;
 import java.util.Date;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InvoiceIT {
 
@@ -270,7 +272,8 @@ class InvoiceIT {
                 .setContextUID(billyAndorra.contexts().andorra().allRegions().getUID())
                 .setProductUID(product.getUID())
                 .setDescription(product.getDescription())
-                .setUnitOfMeasure(product.getUnitOfMeasure());
+                .setUnitOfMeasure(product.getUnitOfMeasure())
+                .setExternalID(ExternalID.fromValue("externalID1"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -285,7 +288,8 @@ class InvoiceIT {
                 .setDescription(productExempt.getDescription())
                 .setUnitOfMeasure(productExempt.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID2"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -300,7 +304,8 @@ class InvoiceIT {
                 .setDescription(productTax.getDescription())
                 .setUnitOfMeasure(productTax.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID3"));
 
         invoiceBuilder.addEntry(entryBuilder);
 

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
@@ -272,7 +272,7 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
 
     @Override
     public Optional<ExternalID<GenericInvoiceEntry>> getExternalID() {
-        return Optional.of(ExternalID.fromValue(externalID));
+        return Optional.ofNullable(ExternalID.fromValue(externalID));
     }
 
     @Override
@@ -408,7 +408,7 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
 
     @Override
     public void setExternalID(final ExternalID<GenericInvoiceEntry> externalID) {
-        this.externalID = externalID.toString();
+        this.externalID = externalID.getIdentifier();
     }
 
 }

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
@@ -18,12 +18,18 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Currency;
-import java.util.Date;
-import java.util.List;
+import com.premiumminds.billy.core.Config;
+import com.premiumminds.billy.core.ExternalID;
+import com.premiumminds.billy.core.persistence.entities.GenericInvoiceEntryEntity;
+import com.premiumminds.billy.core.services.builders.GenericInvoiceEntryBuilder.AmountType;
+import com.premiumminds.billy.core.services.entities.Product;
+import com.premiumminds.billy.core.services.entities.ShippingPoint;
+import com.premiumminds.billy.core.services.entities.Tax;
+import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
+import com.premiumminds.billy.core.services.entities.documents.GenericInvoice.CreditOrDebit;
+import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
+import org.hibernate.envers.Audited;
+
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,18 +43,13 @@ import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
-
-import org.hibernate.envers.Audited;
-
-import com.premiumminds.billy.core.Config;
-import com.premiumminds.billy.core.persistence.entities.GenericInvoiceEntryEntity;
-import com.premiumminds.billy.core.services.builders.GenericInvoiceEntryBuilder.AmountType;
-import com.premiumminds.billy.core.services.entities.Product;
-import com.premiumminds.billy.core.services.entities.ShippingPoint;
-import com.premiumminds.billy.core.services.entities.Tax;
-import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
-import com.premiumminds.billy.core.services.entities.documents.GenericInvoice.CreditOrDebit;
-import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Currency;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 
 @Entity
 @Audited
@@ -142,6 +143,9 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
 
     @Column(name = "AMOUNT_TYPE")
     protected AmountType type;
+
+    @Column(name = "EXTERNAL_ID", unique = true)
+    protected String externalID;
 
     public JPAGenericInvoiceEntryEntity() {
         this.references = new ArrayList<>();
@@ -264,6 +268,11 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
     @Override
     public AmountType getAmountType() {
         return this.type;
+    }
+
+    @Override
+    public Optional<ExternalID<GenericInvoiceEntry>> getExternalID() {
+        return Optional.of(ExternalID.fromValue(externalID));
     }
 
     @Override
@@ -395,6 +404,11 @@ public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEn
     @Override
     public void setAmountType(AmountType type) {
         this.type = type;
+    }
+
+    @Override
+    public void setExternalID(final ExternalID<GenericInvoiceEntry> externalID) {
+        this.externalID = externalID.toString();
     }
 
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/ExternalID.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/ExternalID.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017 Premium Minds.
+ *
+ * This file is part of billy core.
+ *
+ * billy core is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * billy core is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with billy core. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.premiumminds.billy.core;
+
+import java.io.Serializable;
+
+public final class ExternalID<I> implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String value;
+
+    private ExternalID(String value) {
+        this.value = value;
+    }
+
+    public String getIdentifier() {
+        return this.value;
+    }
+
+    public static <I> ExternalID<I> fromValue(String value) {
+        return new ExternalID<>(value);
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null) {
+            return false;
+        } else if (!(obj instanceof ExternalID)) {
+            return false;
+        } else {
+            ExternalID<?> other = (ExternalID)obj;
+            if (this.value == null) {
+                return other.value == null;
+            } else {
+                return this.value.equals(other.value);
+            }
+        }
+    }
+
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + (this.value == null ? 0 : this.value.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return this.value;
+    }
+}

--- a/billy-core/src/main/java/com/premiumminds/billy/core/ExternalID.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/ExternalID.java
@@ -33,7 +33,13 @@ public final class ExternalID<I> implements Serializable {
     }
 
     public static <I> ExternalID<I> fromValue(String value) {
-        return new ExternalID<>(value);
+        final ExternalID<I> result;
+        if (value == null) {
+            result = null;
+        } else {
+            result = new ExternalID<>(value);
+        }
+        return result;
     }
 
     public boolean equals(Object obj) {

--- a/billy-core/src/main/java/com/premiumminds/billy/core/persistence/entities/GenericInvoiceEntryEntity.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/persistence/entities/GenericInvoiceEntryEntity.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.core.persistence.entities;
 
+import com.premiumminds.billy.core.ExternalID;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Currency;
@@ -87,5 +88,7 @@ public interface GenericInvoiceEntryEntity extends GenericInvoiceEntry {
     public void setTaxExemptionCode(String exemptionCode);
 
     public void setAmountType(AmountType type);
+
+    public void setExternalID(ExternalID<GenericInvoiceEntry> externalID);
 
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/GenericInvoiceEntryBuilder.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/GenericInvoiceEntryBuilder.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.core.services.builders;
 
+import com.premiumminds.billy.core.ExternalID;
 import com.premiumminds.billy.core.services.Builder;
 import com.premiumminds.billy.core.services.StringID;
 import com.premiumminds.billy.core.services.entities.Context;
@@ -74,4 +75,5 @@ public interface GenericInvoiceEntryBuilder<TBuilder extends GenericInvoiceEntry
 
     <T extends Tax> TBuilder setTaxes(Collection<T> taxes);
 
+    TBuilder setExternalID(ExternalID<GenericInvoiceEntry> externalID);
 }

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/builders/impl/GenericInvoiceEntryBuilderImpl.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.core.services.builders.impl;
 
+import com.premiumminds.billy.core.ExternalID;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.util.Collection;
@@ -123,6 +124,13 @@ public class GenericInvoiceEntryBuilderImpl<TBuilder extends GenericInvoiceEntry
         BillyValidator.notNull(taxes, "field.taxes");
         this.getTypeInstance().setTaxes(taxes);
 
+        return this.getBuilder();
+    }
+
+    @Override
+    public TBuilder setExternalID(final ExternalID<GenericInvoiceEntry> externalID) {
+        BillyValidator.notNull(externalID, "field.external_id");
+        this.getTypeInstance().setExternalID(externalID);
         return this.getBuilder();
     }
 

--- a/billy-core/src/main/java/com/premiumminds/billy/core/services/entities/documents/GenericInvoiceEntry.java
+++ b/billy-core/src/main/java/com/premiumminds/billy/core/services/entities/documents/GenericInvoiceEntry.java
@@ -18,10 +18,12 @@
  */
 package com.premiumminds.billy.core.services.entities.documents;
 
+import com.premiumminds.billy.core.ExternalID;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Currency;
 import java.util.Date;
+import java.util.Optional;
 import javax.inject.Inject;
 
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
@@ -101,4 +103,5 @@ public interface GenericInvoiceEntry extends Entity<GenericInvoiceEntry> {
 
     AmountType getAmountType();
 
+    Optional<ExternalID<GenericInvoiceEntry>> getExternalID();
 }

--- a/billy-core/src/main/resources/com/premiumminds/billy/core/i18n/FieldNames.properties
+++ b/billy-core/src/main/resources/com/premiumminds/billy/core/i18n/FieldNames.properties
@@ -124,6 +124,7 @@ field.entry_context=Entry Context
 field.tax_exemption_reason=Tax Exemption Reason
 field.tax_exemption_code=Tax Exemption Code
 field.discount_type=Discount Type
+field.external_id=External ID
 
 #Payment
 field.payment_amount=Payment Amount

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/fixtures/MockGenericInvoiceEntryEntity.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/fixtures/MockGenericInvoiceEntryEntity.java
@@ -18,6 +18,7 @@
  */
 package com.premiumminds.billy.core.test.fixtures;
 
+import com.premiumminds.billy.core.ExternalID;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,7 @@ import com.premiumminds.billy.core.services.entities.Tax;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice.CreditOrDebit;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
+import java.util.Optional;
 
 public class MockGenericInvoiceEntryEntity extends MockBaseEntity<GenericInvoiceEntry> implements GenericInvoiceEntryEntity {
 
@@ -63,6 +65,7 @@ public class MockGenericInvoiceEntryEntity extends MockBaseEntity<GenericInvoice
     public BigDecimal unitDiscountAmount;
     public String unitOfMeasure;
     public AmountType type;
+    public ExternalID<GenericInvoiceEntry> externalID;
 
     public MockGenericInvoiceEntryEntity() {
         this.references = new ArrayList<>();
@@ -182,6 +185,11 @@ public class MockGenericInvoiceEntryEntity extends MockBaseEntity<GenericInvoice
     @Override
     public AmountType getAmountType() {
         return this.type;
+    }
+
+    @Override
+    public Optional<ExternalID<GenericInvoiceEntry>> getExternalID() {
+        return Optional.ofNullable(externalID);
     }
 
     @Override
@@ -313,5 +321,10 @@ public class MockGenericInvoiceEntryEntity extends MockBaseEntity<GenericInvoice
     @Override
     public void setAmountType(AmountType type) {
         this.type = type;
+    }
+
+    @Override
+    public void setExternalID(final ExternalID<GenericInvoiceEntry> externalID) {
+        this.externalID = externalID;
     }
 }

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryBuilder.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryBuilder.java
@@ -73,7 +73,8 @@ class TestGenericInvoiceEntryBuilder extends AbstractTest {
                 .setShippingCostsAmount(mock.getShippingCostsAmount())
                 .setUnitAmount(AmountType.WITH_TAX, mock.getUnitAmountWithTax())
                 .setUnitOfMeasure(mock.getUnitOfMeasure()).setProductUID(mock.getProduct().getUID())
-                .setTaxPointDate(mock.getTaxPointDate()).setCurrency(Currency.getInstance("EUR"));
+                .setTaxPointDate(mock.getTaxPointDate()).setCurrency(Currency.getInstance("EUR"))
+                .setExternalID(mock.getExternalID().orElseThrow());
 
         GenericInvoiceEntry entry = builder.build();
 
@@ -90,6 +91,7 @@ class TestGenericInvoiceEntryBuilder extends AbstractTest {
         Assertions.assertEquals(0, mock.getAmountWithoutTax().compareTo(entry.getAmountWithoutTax()));
         Assertions.assertEquals(0, mock.getTaxAmount().compareTo(entry.getTaxAmount()));
         Assertions.assertEquals(0, mock.getDiscountAmount().compareTo(entry.getDiscountAmount()));
+        Assertions.assertEquals(mock.getExternalID().orElseThrow(), entry.getExternalID().orElseThrow());
 
     }
 

--- a/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryOperations.java
+++ b/billy-core/src/test/java/com/premiumminds/billy/core/test/services/builders/TestGenericInvoiceEntryOperations.java
@@ -18,15 +18,6 @@
  */
 package com.premiumminds.billy.core.test.services.builders;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.util.Currency;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
 import com.premiumminds.billy.core.persistence.dao.DAOContext;
 import com.premiumminds.billy.core.persistence.dao.DAOGenericInvoice;
 import com.premiumminds.billy.core.persistence.dao.DAOGenericInvoiceEntry;
@@ -39,11 +30,19 @@ import com.premiumminds.billy.core.test.AbstractTest;
 import com.premiumminds.billy.core.test.fixtures.MockGenericInvoiceEntity;
 import com.premiumminds.billy.core.test.fixtures.MockGenericInvoiceEntryEntity;
 import com.premiumminds.billy.core.util.BillyMathContext;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-public class TestGenericInvoiceEntryOperations extends AbstractTest {
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.Currency;
 
-    private MathContext mc = BillyMathContext.get();
-    private BigDecimal qnt = new BigDecimal("46");
+class TestGenericInvoiceEntryOperations extends AbstractTest {
+
+    private final MathContext mc = BillyMathContext.get();
+    private final BigDecimal qnt = new BigDecimal("46");
     private static final String INVOICE_YML = AbstractTest.YML_CONFIGS_DIR + "GenericInvoice.yml";
     private static final String ENTRY_YML = AbstractTest.YML_CONFIGS_DIR + "GenericInvoiceEntry.yml";
     MockGenericInvoiceEntryEntity mock;
@@ -73,54 +72,54 @@ public class TestGenericInvoiceEntryOperations extends AbstractTest {
         Mockito.when(this.getInstance(DAOProduct.class).get(Mockito.any()))
                 .thenReturn((ProductEntity) this.mock.getProduct());
 
-        this.builder = this.getEntryEntityBuilder(this.invoiceMock, this.mock);
+        this.builder = this.getEntryEntityBuilder(this.mock);
 
-        this.entry = this.getEntryEntityBuilder(this.invoiceMock, this.mock).build();
+        this.entry = this.getEntryEntityBuilder(this.mock).build();
 
     }
 
     @Test
-    public void testOperations() {
+    void testOperations() {
 
-        Assertions.assertTrue(this.entry.getAmountWithoutTax().compareTo(this.mock.getAmountWithoutTax()) == 0);
+        Assertions.assertEquals(0, this.entry.getAmountWithoutTax().compareTo(this.mock.getAmountWithoutTax()));
 
-        Assertions.assertTrue(this.entry.getAmountWithoutTax()
-                .compareTo(this.mock.getUnitAmountWithoutTax().multiply(this.qnt, this.mc)) == 0);
+        Assertions.assertEquals(0, this.entry.getAmountWithoutTax()
+                .compareTo(this.mock.getUnitAmountWithoutTax().multiply(this.qnt, this.mc)));
 
-        Assertions.assertTrue(this.entry.getAmountWithoutTax()
-                .compareTo((this.mock.getAmountWithTax().subtract(this.mock.getTaxAmount(), this.mc))) == 0);
+        Assertions.assertEquals(0, this.entry.getAmountWithoutTax()
+                .compareTo((this.mock.getAmountWithTax().subtract(this.mock.getTaxAmount(), this.mc))));
 
-        Assertions.assertTrue(this.entry.getAmountWithTax()
-                .compareTo(this.mock.getAmountWithTax().setScale(7, this.mc.getRoundingMode())) == 0);
+        Assertions.assertEquals(0, this.entry.getAmountWithTax()
+                .compareTo(this.mock.getAmountWithTax().setScale(7, this.mc.getRoundingMode())));
 
-        Assertions.assertTrue(this.entry.getAmountWithTax()
-                .compareTo(this.mock.getUnitAmountWithTax().multiply(this.qnt, this.mc)) == 0);
+        Assertions.assertEquals(0,
+                this.entry.getAmountWithTax().compareTo(this.mock.getUnitAmountWithTax().multiply(this.qnt, this.mc)));
 
-        Assertions.assertTrue(this.entry.getAmountWithTax()
-                .compareTo((this.mock.getTaxAmount().add(this.mock.getAmountWithoutTax(), this.mc))) == 0);
+        Assertions.assertEquals(0, this.entry.getAmountWithTax()
+                .compareTo((this.mock.getTaxAmount().add(this.mock.getAmountWithoutTax(), this.mc))));
 
-        Assertions.assertTrue(this.entry.getTaxAmount().compareTo(this.mock.getTaxAmount()) == 0);
+        Assertions.assertEquals(0, this.entry.getTaxAmount().compareTo(this.mock.getTaxAmount()));
 
-        Assertions.assertTrue(this.entry.getTaxAmount()
-                .compareTo((this.mock.getAmountWithTax().subtract(this.mock.getAmountWithoutTax()))) == 0);
+        Assertions.assertEquals(0, this.entry.getTaxAmount()
+                .compareTo((this.mock.getAmountWithTax().subtract(this.mock.getAmountWithoutTax()))));
 
-        Assertions.assertTrue(
-                this.entry.getTaxAmount().compareTo(this.mock.getUnitTaxAmount().multiply(this.qnt, this.mc)) == 0);
+        Assertions.assertEquals(0,
+                this.entry.getTaxAmount().compareTo(this.mock.getUnitTaxAmount().multiply(this.qnt, this.mc)));
 
-        Assertions.assertTrue(this.entry.getUnitAmountWithTax().compareTo(this.mock.getUnitAmountWithTax()) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithTax().compareTo(this.mock.getUnitAmountWithTax()));
 
-        Assertions.assertTrue(this.entry.getUnitAmountWithTax().compareTo((this.mock.getUnitAmountWithoutTax()
-                .add(this.mock.getUnitAmountWithoutTax().multiply(new BigDecimal("0.23"), this.mc), this.mc))) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithTax().compareTo((this.mock.getUnitAmountWithoutTax()
+                .add(this.mock.getUnitAmountWithoutTax().multiply(new BigDecimal("0.23"), this.mc), this.mc))));
 
-        Assertions.assertTrue(this.entry.getUnitAmountWithoutTax().compareTo(this.mock.getUnitAmountWithoutTax()) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithoutTax().compareTo(this.mock.getUnitAmountWithoutTax()));
 
-        Assertions.assertTrue(this.entry.getUnitAmountWithoutTax()
-                .compareTo((this.mock.getUnitAmountWithTax().subtract(this.mock.getUnitTaxAmount(), this.mc))) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithoutTax()
+                .compareTo((this.mock.getUnitAmountWithTax().subtract(this.mock.getUnitTaxAmount(), this.mc))));
 
-        Assertions.assertTrue(this.entry.getUnitTaxAmount().compareTo(this.mock.getUnitTaxAmount()) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitTaxAmount().compareTo(this.mock.getUnitTaxAmount()));
 
-        Assertions.assertTrue(this.entry.getUnitTaxAmount().compareTo(
-                (this.mock.getUnitAmountWithTax().subtract(this.mock.getUnitAmountWithoutTax(), this.mc))) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitTaxAmount()
+                .compareTo((this.mock.getUnitAmountWithTax().subtract(this.mock.getUnitAmountWithoutTax(), this.mc))));
 
         try {
             this.builder.setQuantity(new BigDecimal("-1"));
@@ -128,14 +127,14 @@ public class TestGenericInvoiceEntryOperations extends AbstractTest {
         } catch (IllegalArgumentException e) {
         }
 
-        Assertions.assertTrue(this.entry.getUnitAmountWithoutTax().compareTo(this.mock.getUnitAmountWithoutTax()) == 0);
-        Assertions.assertTrue(this.entry.getUnitAmountWithTax().compareTo(this.mock.getUnitAmountWithTax()) == 0);
-        Assertions.assertTrue(this.entry.getUnitTaxAmount().compareTo(this.mock.getUnitTaxAmount()) == 0);
-        Assertions.assertTrue(this.entry.getTaxAmount().compareTo(this.mock.getTaxAmount()) == 0);
-        Assertions.assertTrue(this.entry.getAmountWithoutTax().compareTo(this.mock.getAmountWithoutTax()) == 0);
-        Assertions.assertTrue(this.entry.getAmountWithTax().compareTo(this.mock.getAmountWithTax()) == 0);
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithoutTax().compareTo(this.mock.getUnitAmountWithoutTax()));
+        Assertions.assertEquals(0, this.entry.getUnitAmountWithTax().compareTo(this.mock.getUnitAmountWithTax()));
+        Assertions.assertEquals(0, this.entry.getUnitTaxAmount().compareTo(this.mock.getUnitTaxAmount()));
+        Assertions.assertEquals(0, this.entry.getTaxAmount().compareTo(this.mock.getTaxAmount()));
+        Assertions.assertEquals(0, this.entry.getAmountWithoutTax().compareTo(this.mock.getAmountWithoutTax()));
+        Assertions.assertEquals(0, this.entry.getAmountWithTax().compareTo(this.mock.getAmountWithTax()));
 
-        return;
+        Assertions.assertEquals(this.mock.getExternalID().orElseThrow(), this.entry.getExternalID().orElseThrow());
     }
 
     public MockGenericInvoiceEntryEntity getMockEntryEntity(MockGenericInvoiceEntity invoice, BigDecimal unitValue) {
@@ -157,8 +156,7 @@ public class TestGenericInvoiceEntryOperations extends AbstractTest {
         return result;
     }
 
-    public GenericInvoiceEntry.Builder getEntryEntityBuilder(MockGenericInvoiceEntity invoice,
-            MockGenericInvoiceEntryEntity mockEntry) {
+    public GenericInvoiceEntry.Builder getEntryEntityBuilder(MockGenericInvoiceEntryEntity mockEntry) {
 
         GenericInvoiceEntry.Builder builder = this.getInstance(GenericInvoiceEntry.Builder.class);
 
@@ -167,7 +165,8 @@ public class TestGenericInvoiceEntryOperations extends AbstractTest {
                 .setQuantity(mockEntry.getQuantity()).setShippingCostsAmount(mockEntry.getShippingCostsAmount())
                 .setUnitAmount(AmountType.WITHOUT_TAX, mockEntry.getUnitAmountWithoutTax())
                 .setUnitOfMeasure(mockEntry.getUnitOfMeasure()).setProductUID(mockEntry.getProduct().getUID())
-                .setTaxPointDate(mockEntry.getTaxPointDate()).setCurrency(mockEntry.getCurrency());
+                .setTaxPointDate(mockEntry.getTaxPointDate()).setCurrency(mockEntry.getCurrency())
+                .setExternalID(mockEntry.getExternalID().orElseThrow());
 
         return builder;
     }

--- a/billy-core/src/test/resources/yml/GenericInvoiceEntry.yml
+++ b/billy-core/src/test/resources/yml/GenericInvoiceEntry.yml
@@ -61,7 +61,7 @@ product : !!com.premiumminds.billy.core.test.fixtures.MockProductEntity
             uid : context_parent_uid
             name : PT
             description : PT
-            
+
 quantity : !!java.math.BigDecimal
   46
 shippingCostsAmount : !!java.math.BigDecimal
@@ -127,3 +127,4 @@ unitTaxAmount : !!java.math.BigDecimal
 unitDiscountAmount : !!java.math.BigDecimal
   0
 unitOfMeasure : kg
+externalID: externalID

--- a/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
+++ b/billy-france/src/main/resources/com/premiumminds/billy/france/i18n/FieldNames_fr.properties
@@ -133,6 +133,7 @@ field.discount_type=Type de remise
 field.invoice_reference=Référence à la facture
 field.reason=Raison de l'émission de note de crédit
 field.taxes=Impôts
+field.external_id=ID Externe
 
 #Product
 field.product_code=Code produit

--- a/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
+++ b/billy-portugal/src/main/resources/com/premiumminds/billy/portugal/i18n/FieldNames_pt.properties
@@ -137,6 +137,7 @@ field.discount_type=Tipo de Desconto
 field.invoice_reference=Referência para a Factura
 field.reason=Razão da Emissão da Nota de Crédito
 field.taxes=Impostos
+field.external_id=ID Externo
 
 #Payment
 field.payment_amount=Valor do Pagamento

--- a/billy-portugal/src/test/java/com/premiumminds/billy/portugal/its/InvoiceIT.java
+++ b/billy-portugal/src/test/java/com/premiumminds/billy/portugal/its/InvoiceIT.java
@@ -18,11 +18,9 @@
  */
 package com.premiumminds.billy.portugal.its;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.premiumminds.billy.core.ExternalID;
 import com.premiumminds.billy.core.exceptions.SeriesUniqueCodeNotFilled;
 import com.premiumminds.billy.core.persistence.dao.DAOInvoiceSeries;
 import com.premiumminds.billy.core.persistence.entities.InvoiceSeriesEntity;
@@ -54,6 +52,14 @@ import com.premiumminds.billy.portugal.services.entities.PTProduct;
 import com.premiumminds.billy.portugal.services.entities.PTTax;
 import com.premiumminds.billy.portugal.services.export.saftpt.PTSAFTFileGenerator;
 import com.premiumminds.billy.portugal.util.KeyGenerator;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
@@ -63,13 +69,9 @@ import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Currency;
 import java.util.Date;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-import org.junit.jupiter.api.Test;
-import org.w3c.dom.Document;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InvoiceIT {
 
@@ -308,7 +310,8 @@ public class InvoiceIT {
                 .setContextUID(billyPortugal.contexts().continent().allContinentRegions().getUID())
                 .setProductUID(product.getUID())
                 .setDescription(product.getDescription())
-                .setUnitOfMeasure(product.getUnitOfMeasure());
+                .setUnitOfMeasure(product.getUnitOfMeasure())
+                .setExternalID(ExternalID.fromValue("externalID1"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -323,7 +326,8 @@ public class InvoiceIT {
                 .setDescription(productExempt.getDescription())
                 .setUnitOfMeasure(productExempt.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID2"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -338,7 +342,8 @@ public class InvoiceIT {
                 .setDescription(productTax.getDescription())
                 .setUnitOfMeasure(productTax.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID3"));
 
         invoiceBuilder.addEntry(entryBuilder);
 

--- a/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
+++ b/billy-spain/src/main/resources/com/premiumminds/billy/spain/i18n/FieldNames_es.properties
@@ -135,6 +135,7 @@ field.discount_type=Tipo de Descuento
 field.invoice_reference=Referencia para la Factura
 field.reason=Motivo de la Emisión de la Nota de Abono
 field.taxes=Impuestos
+field.external_id=ID Externo
 
 #Product
 field.product_code=Código del Producto

--- a/billy-spain/src/test/java/com/premiumminds/billy/spain/its/InvoiceIT.java
+++ b/billy-spain/src/test/java/com/premiumminds/billy/spain/its/InvoiceIT.java
@@ -18,10 +18,9 @@
  */
 package com.premiumminds.billy.spain.its;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.premiumminds.billy.core.ExternalID;
 import com.premiumminds.billy.core.exceptions.SeriesUniqueCodeNotFilled;
 import com.premiumminds.billy.core.persistence.dao.DAOInvoiceSeries;
 import com.premiumminds.billy.core.persistence.entities.InvoiceSeriesEntity;
@@ -52,13 +51,16 @@ import com.premiumminds.billy.spain.services.entities.ESInvoiceEntry;
 import com.premiumminds.billy.spain.services.entities.ESPayment;
 import com.premiumminds.billy.spain.services.entities.ESProduct;
 import com.premiumminds.billy.spain.services.entities.ESTax;
+import org.junit.jupiter.api.Test;
+
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
 import java.util.Currency;
 import java.util.Date;
-import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class InvoiceIT {
 
@@ -252,7 +254,8 @@ class InvoiceIT {
                 .setContextUID(billySpain.contexts().continent().allContinentRegions().getUID())
                 .setProductUID(product.getUID())
                 .setDescription(product.getDescription())
-                .setUnitOfMeasure(product.getUnitOfMeasure());
+                .setUnitOfMeasure(product.getUnitOfMeasure())
+                .setExternalID(ExternalID.fromValue("externalID1"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -267,7 +270,8 @@ class InvoiceIT {
                 .setDescription(productExempt.getDescription())
                 .setUnitOfMeasure(productExempt.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID2"));
 
         invoiceBuilder.addEntry(entryBuilder);
 
@@ -282,7 +286,8 @@ class InvoiceIT {
                 .setDescription(productTax.getDescription())
                 .setUnitOfMeasure(productTax.getUnitOfMeasure())
                 .setTaxExemptionCode("M99")
-                .setTaxExemptionReason("reason 1");
+                .setTaxExemptionReason("reason 1")
+                .setExternalID(ExternalID.fromValue("externalID3"));
 
         invoiceBuilder.addEntry(entryBuilder);
 


### PR DESCRIPTION
The purpose of this field to hold a reference passed by the clients of the lib to allow the identification of a given entry and match it to a representation held in the client