### PR TITLE
Add inheritance annotation to all core entities that are extended in

### DIFF
--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAAddressEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAAddressEntity.java
@@ -18,19 +18,21 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.services.entities.Address;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "ADDRESS")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAAddressEntity extends JPABaseEntity<Address> implements AddressEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAApplicationEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAApplicationEntity.java
@@ -18,29 +18,31 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.ApplicationEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.entities.Application;
 import com.premiumminds.billy.core.services.entities.Contact;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "APPLICATION")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAApplicationEntity extends JPABaseEntity<Application> implements ApplicationEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPABusinessEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPABusinessEntity.java
@@ -36,6 +36,8 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
@@ -49,6 +51,7 @@ import java.util.List;
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "BUSINESS")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPABusinessEntity extends JPABaseEntity<Business> implements BusinessEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAContactEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAContactEntity.java
@@ -18,19 +18,21 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
 import com.premiumminds.billy.core.services.entities.Contact;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "CONTACT")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAContactEntity extends JPABaseEntity<Contact> implements ContactEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAContextEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAContextEntity.java
@@ -18,21 +18,23 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
+import com.premiumminds.billy.core.Config;
+import com.premiumminds.billy.core.persistence.entities.ContextEntity;
+import com.premiumminds.billy.core.services.entities.Context;
+import org.hibernate.envers.Audited;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import org.hibernate.envers.Audited;
-
-import com.premiumminds.billy.core.Config;
-import com.premiumminds.billy.core.persistence.entities.ContextEntity;
-import com.premiumminds.billy.core.services.entities.Context;
-
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "CONTEXT")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAContextEntity extends JPABaseEntity<Context> implements ContextEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPACustomerEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPACustomerEntity.java
@@ -18,19 +18,6 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
@@ -39,10 +26,25 @@ import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.BankAccount;
 import com.premiumminds.billy.core.services.entities.Contact;
 import com.premiumminds.billy.core.services.entities.Customer;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "CUSTOMER")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPACustomerEntity extends JPABaseEntity<Customer> implements CustomerEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntity.java
@@ -30,12 +30,8 @@ import com.premiumminds.billy.core.services.entities.ShippingPoint;
 import com.premiumminds.billy.core.services.entities.Supplier;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoice;
 import com.premiumminds.billy.core.services.entities.documents.GenericInvoiceEntry;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Currency;
-import java.util.Date;
-import java.util.List;
+import org.hibernate.envers.Audited;
+
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -43,6 +39,8 @@ import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToOne;
@@ -52,13 +50,19 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
-import org.hibernate.envers.Audited;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Currency;
+import java.util.Date;
+import java.util.List;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "GENERIC_INVOICE",
         uniqueConstraints = { @UniqueConstraint(columnNames = { "NUMBER", "ID_BUSINESS" }),
                 @UniqueConstraint(columnNames = { "SERIES", "SERIES_NUMBER", "ID_BUSINESS" }) })
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAGenericInvoiceEntity extends JPABaseEntity<GenericInvoice> implements GenericInvoiceEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAGenericInvoiceEntryEntity.java
@@ -35,6 +35,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
@@ -54,6 +56,7 @@ import java.util.Optional;
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "GENERIC_INVOICE_ENTRY")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAGenericInvoiceEntryEntity extends JPABaseEntity<GenericInvoiceEntry> implements GenericInvoiceEntryEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAPaymentEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAPaymentEntity.java
@@ -18,22 +18,24 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.Date;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.PaymentEntity;
 import com.premiumminds.billy.core.services.entities.Payment;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "PAYMENT")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAPaymentEntity extends JPABaseEntity<Payment> implements PaymentEntity {
 
     /**

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAProductEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAProductEntity.java
@@ -18,27 +18,29 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.ManyToMany;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.ProductEntity;
 import com.premiumminds.billy.core.services.entities.Product;
 import com.premiumminds.billy.core.services.entities.Tax;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "PRODUCT")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAProductEntity extends JPABaseEntity<Product> implements ProductEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAShippingPointEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPAShippingPointEntity.java
@@ -18,27 +18,29 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.Date;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ShippingPointEntity;
 import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.ShippingPoint;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.util.Date;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "SHIPPING_POINT")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPAShippingPointEntity extends JPABaseEntity<ShippingPoint> implements ShippingPointEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPASupplierEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPASupplierEntity.java
@@ -18,19 +18,6 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.JoinTable;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
-import javax.persistence.Table;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.AddressEntity;
 import com.premiumminds.billy.core.persistence.entities.ContactEntity;
@@ -39,10 +26,25 @@ import com.premiumminds.billy.core.services.entities.Address;
 import com.premiumminds.billy.core.services.entities.BankAccount;
 import com.premiumminds.billy.core.services.entities.Contact;
 import com.premiumminds.billy.core.services.entities.Supplier;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "SUPPLIER")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPASupplierEntity extends JPABaseEntity<Supplier> implements SupplierEntity {
 
     private static final long serialVersionUID = 1L;

--- a/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPATaxEntity.java
+++ b/billy-core-jpa/src/main/java/com/premiumminds/billy/persistence/entities/jpa/JPATaxEntity.java
@@ -18,30 +18,32 @@
  */
 package com.premiumminds.billy.persistence.entities.jpa;
 
-import java.math.BigDecimal;
-import java.util.Currency;
-import java.util.Date;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.Temporal;
-import javax.persistence.TemporalType;
-
-import org.hibernate.envers.Audited;
-
 import com.premiumminds.billy.core.Config;
 import com.premiumminds.billy.core.persistence.entities.ContextEntity;
 import com.premiumminds.billy.core.persistence.entities.TaxEntity;
 import com.premiumminds.billy.core.services.entities.Context;
 import com.premiumminds.billy.core.services.entities.Tax;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import java.math.BigDecimal;
+import java.util.Currency;
+import java.util.Date;
 
 @Entity
 @Audited
 @Table(name = Config.TABLE_PREFIX + "TAX")
+@Inheritance(strategy = InheritanceType.JOINED)
 public class JPATaxEntity extends JPABaseEntity<Tax> implements TaxEntity {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
country modules

This annotation was previously being set in JPABaseEntity but was removed in #498. This change resulted in a change to the schema required by the application that was only detected when a client application was updated since the schema used during tests is generated from the code meaning it is always correct.

Adding the annotation back to all entities that are extended in the various submodules resolves this problem since hibernate once again knows how the schema of the application should be assembled